### PR TITLE
Moved flipRegion to its own file

### DIFF
--- a/public/js/microdraw.js
+++ b/public/js/microdraw.js
@@ -909,27 +909,6 @@ var Microdraw = (function () {
                 paper.view.draw();
             }
         },
-
-        /**
-         * @function flipRegion
-         * @desc Flip region along y-axis around its center point
-         * @returns {void}
-         */
-        flipRegion: function flipRegion() {
-            if( me.region !== null ) {
-                if( me.debug ) { console.log("> flipping region"); }
-
-                var i;
-                for( i in me.ImageInfo[me.currentImage].Regions ) {
-                    if( me.ImageInfo[me.currentImage].Regions[i].path.selected ) {
-                        me.ImageInfo[me.currentImage].Regions[i].path.scale(-1, 1);
-                    }
-                }
-                paper.view.draw();
-            }
-        },
-
-
         /**
          * @function setRegionColor
          * @desc Set picked color & alpha
@@ -1373,11 +1352,6 @@ var Microdraw = (function () {
                     //me.backToPreviousTool(prevTool);
                     me.backToSelect();
                     break;
-                case "flip":
-                    me.flipRegion(me.region);
-                    //backToPreviousTool(prevTool);
-                    me.backToSelect();
-                    break;
                 case "closeMenu":
                     me.toggleMenu();
                     me.backToPreviousTool(prevTool);
@@ -1392,7 +1366,8 @@ var Microdraw = (function () {
                 /**
                  * @todo These are the tools that have been already encapsulated. The switch/case should be removed when the encapsulation of all tools is finished
                  */
-                 
+
+                case "flip":
                 case "draw":
                 case "drawPolygon":
                 case "toBezier":
@@ -2172,6 +2147,7 @@ var Microdraw = (function () {
             $.when(
                 me.loadScript('/js/tools/draw.js'),
                 me.loadScript('/js/tools/drawPolygon.js'),
+                me.loadScript('/js/tools/flipRegion.js'),
                 me.loadScript('/js/tools/screenshot.js'),
                 me.loadScript('/js/tools/toBezier.js'),
                 me.loadScript('/js/tools/toPolygon.js')
@@ -2179,6 +2155,7 @@ var Microdraw = (function () {
                 me.tools = {};
                 $.extend(me.tools, ToolDraw);
                 $.extend(me.tools, ToolDrawPolygon);
+                $.extend(me.tools, ToolFlipRegion);
                 $.extend(me.tools, ToolScreenshot);
                 $.extend(me.tools, ToolToBezier);
                 $.extend(me.tools, ToolToPolygon);

--- a/public/js/tools/flipRegion.js
+++ b/public/js/tools/flipRegion.js
@@ -1,0 +1,37 @@
+/*global Microdraw*/
+/*global paper*/
+
+var ToolFlipRegion = {flip: (function() {
+    var tool = {
+         /**
+         * @function flipRegion
+         * @desc Flip region along y-axis around its center point
+         * @returns {void}
+         */
+        flip: function flipRegion() {
+            if( Microdraw.region !== null ) {
+                if( Microdraw.debug ) { console.log("> flipping region"); }
+
+                var i;
+                for( i in Microdraw.ImageInfo[Microdraw.currentImage].Regions ) {
+                    if( Microdraw.ImageInfo[Microdraw.currentImage].Regions[i].path.selected ) {
+                        Microdraw.ImageInfo[Microdraw.currentImage].Regions[i].path.scale(-1, 1);
+                    }
+                }
+                paper.view.draw();
+            }
+        },
+
+        /*
+         * @function click
+         * @desc Convert bezier curve into polygon path
+         * @param {string} prevTool The previous tool to which the selection goes back
+         * @returns {void}
+         */
+        click: function click(prevTool) {
+            tool.flip();
+            Microdraw.backToPreviousTool(prevTool);
+        }
+    };
+    return tool;
+})()};


### PR DESCRIPTION
<!-- Thank you so much for your contribution to MicroDraw! <3 -->

<!-- Please find a short title for your pull request and describe your changes on the following line: -->


---
<!-- Please go through our check list and replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `screenshot_test_walk` generates the same test pictures as there were and does not show any errors **not sure how to run this**
- [x] These changes partially helps with #75 (github issue number if applicable).
- [x] All MicroDraw tools behave as expected:
    * **GESTURES**
        - [x] zoom in and out with two finger drag works
    * **KEYS**
        * right and up arrow key or left and down arrow key
            - [x] jump to next or previous slice respectively
            - [x] update the slider accordingly
            - [x] update the slice number accordingly 
        * cmd z undoes
            - [x] any step back that you have done in their chronological order including
            - [x] translation of region
            - [x] drawing region
            - [x] adding point
            - [x] deleting point
        to be completed (maybe it is implemented and working for all functions, so we can delete the single step checks)
    * **TOOL BUTTONS**
        * red rectangle in navigation window 
            - [x] corresponds to tissue piece selected in viewer
            - [x] can be moved upon mouse down drag
        * navigation tool 
            - [x] moves the slice inside the viewer upon on mouse down drag
        to be continued...
        
            
