### PR TITLE
Fix scalebar overlap with login panel

### DIFF
--- a/public/js/microdraw.js
+++ b/public/js/microdraw.js
@@ -2366,7 +2366,7 @@ var Microdraw = (function () {
                 barThickness:4,
                 location: OpenSeadragon.ScalebarLocation.TOP_RIGHT,
                 xOffset:5,
-                yOffset:5
+                yOffset:25
             });
 
             // add screenshot

--- a/public/js/microdraw.js
+++ b/public/js/microdraw.js
@@ -2366,8 +2366,84 @@ var Microdraw = (function () {
                 barThickness:4,
                 location: OpenSeadragon.ScalebarLocation.TOP_RIGHT,
                 xOffset:5,
-                yOffset:25
+                yOffset:5
             });
+
+            OpenSeadragon.Scalebar.prototype.getScalebarLocation = (function() {
+                if (this.location === OpenSeadragon.ScalebarLocation.TOP_LEFT) {
+                    var x = 0;
+                    var y = 0;
+                    if (this.stayInsideImage) {
+                        var pixel = this.viewer.viewport.pixelFromPoint(
+                                new OpenSeadragon.Point(0, 0), true);
+                        if (!this.viewer.wrapHorizontal) {
+                            x = Math.max(pixel.x, 0);
+                        }
+                        if (!this.viewer.wrapVertical) {
+                            y = Math.max(pixel.y, 0);
+                        }
+                    }
+
+                    return new OpenSeadragon.Point(x + this.xOffset, y + this.yOffset);
+                }
+                if (this.location === OpenSeadragon.ScalebarLocation.TOP_RIGHT) {
+                    var barWidth = this.divElt.offsetWidth;
+                    var container = this.viewer.container;
+                    var x = container.offsetWidth - barWidth;
+                    var y = 0;
+                    if (this.stayInsideImage) {
+                        var pixel = this.viewer.viewport.pixelFromPoint(
+                                new OpenSeadragon.Point(1, 0), true);
+                        if (!this.viewer.wrapHorizontal) {
+                            x = Math.min(x, pixel.x - barWidth);
+                        }
+                        if (!this.viewer.wrapVertical) {
+                            y = Math.max(y + 20, pixel.y);
+                        }
+                    }
+
+                    return new OpenSeadragon.Point(x - this.xOffset, y + this.yOffset);
+                }
+                if (this.location === OpenSeadragon.ScalebarLocation.BOTTOM_RIGHT) {
+                    var barWidth = this.divElt.offsetWidth;
+                    var barHeight = this.divElt.offsetHeight;
+                    var container = this.viewer.container;
+                    var x = container.offsetWidth - barWidth;
+                    var y = container.offsetHeight - barHeight;
+                    if (this.stayInsideImage) {
+                        var pixel = this.viewer.viewport.pixelFromPoint(
+                                new OpenSeadragon.Point(1, 1 / this.viewer.source.aspectRatio),
+                                true);
+                        if (!this.viewer.wrapHorizontal) {
+                            x = Math.min(x, pixel.x - barWidth);
+                        }
+                        if (!this.viewer.wrapVertical) {
+                            y = Math.min(y, pixel.y - barHeight);
+                        }
+                    }
+
+                    return new OpenSeadragon.Point(x - this.xOffset, y - this.yOffset);
+                }
+                if (this.location === OpenSeadragon.ScalebarLocation.BOTTOM_LEFT) {
+                    var barHeight = this.divElt.offsetHeight;
+                    var container = this.viewer.container;
+                    var x = 0;
+                    var y = container.offsetHeight - barHeight;
+                    if (this.stayInsideImage) {
+                        var pixel = this.viewer.viewport.pixelFromPoint(
+                                new OpenSeadragon.Point(0, 1 / this.viewer.source.aspectRatio),
+                                true);
+                        if (!this.viewer.wrapHorizontal) {
+                            x = Math.max(x, pixel.x);
+                        }
+                        if (!this.viewer.wrapVertical) {
+                            y = Math.min(y, pixel.y - barHeight);
+                        }
+                    }
+
+                    return new OpenSeadragon.Point(x + this.xOffset, y - this.yOffset);
+                }
+            }).bind(me.viewer.scalebarInstance);
 
             // add screenshot
             me.viewer.screenshot({


### PR DESCRIPTION
<!-- Thank you so much for your contribution to MicroDraw! <3 -->

<!-- Please find a short title for your pull request and describe your changes on the following line: -->
Current behaviour:
![scalebarcurrent](https://user-images.githubusercontent.com/19381783/31937620-5f340b5a-b8b5-11e7-9fb1-6affc3ee5d86.png)

New behaviour:
![scalebarfix1](https://user-images.githubusercontent.com/19381783/31937634-67afacf8-b8b5-11e7-9bcc-01141a4ee285.PNG)
![scalebarfix2](https://user-images.githubusercontent.com/19381783/31937639-6943cbc6-b8b5-11e7-8f0e-a5739cde4e98.PNG)


---
<!-- Please go through our check list and replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `screenshot_test_walk` generates the same test pictures as there were and does not show any errors ( does not generate the same as reference by design )
- [x] These changes fix #100  (github issue number if applicable).
- [x] All MicroDraw tools behave as expected:
    * **GESTURES**
        - [x] zoom in and out with two finger drag works
    * **KEYS**
        * right and up arrow key or left and down arrow key
            - [x] jump to next or previous slice respectively
            - [x] update the slider accordingly
            - [x] update the slice number accordingly 
        * cmd z undoes
            - [x] any step back that you have done in their chronological order including
            - [x] translation of region
            - [x] drawing region
            - [x] adding point
            - [x] deleting point
        to be completed (maybe it is implemented and working for all functions, so we can delete the single step checks)
    * **TOOL BUTTONS**
        * red rectangle in navigation window 
            - [x] corresponds to tissue piece selected in viewer
            - [x] can be navigated upon mouse down drag
        * navigation tool 
            - [x] navigates the slice inside the viewer upon mouse down drag
        * home button
            - [x] zooms out to view the data in full screen size view
        * zoomIn tool
            - [x] zooms one step in upon click
        * zoomOut tool
            - [x] zooms one step out upon click
        * left arrow
            - [x] jumps to the previous slice
        * right arrow
            - [x] jumps to the next slice
        * select tool
            - [x] selects a region upon click
        * draw tool
            - [x] draws a new region as bezier curve
        * drawPolygon tool
            - [x] draws a new region as a polygon path
        * simplify tool
            - [x] decreases the number of points in the region path while aiming at conserving the shape
        * addPoint tool
            - [x] adds a point to the path upon click at position of mouse click
        * deletePoint tool
            - [x] deletes a point from the path upon mouse click
        * addRegion tool
            - [x] unifies two overlapping regions into one
        * deleteRegion tool
            - [x] deletes a region upon click
        * splitRegion tool
            - [x] splits one region at the intersection path with a second region
        * rotate tool
            - [x] rotates a region around the point of mouse click
        * flip tool
            - [x] flips a region around its vertical axis
        * toPolygon tool
            - [x] converts the region path from bezier curve to polygon path
        * toBezier
            - [x] converts the region path from polygon path to bezier curve
        * copy tool
            - [x] copies a region
        * paste tool
            - [x] pastes the copied region
        * save tool
            - [x] saves the set of drawn regions to the database
        * screenshot tool
            - [x] creates a screenshot of the data layer (not of the annotations yet) at a chosen resolution
        * delete tool
            - [x] deletes the selected region
        * closeMenu tool
            - [x] hides the menu bar upon click
        * openMenu tool
            - [x] shows the menu bar upon click
        * undo tool
            - [x] undoes the user's actions in reverse chronological order
        
            
<!-- Either: -->
- [ ] I implemented tests for these changes OR
- [x] These changes do not require tests because existing tests already tests for this change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Again, many many thanks for your work! \ö/ -->

