### PR TITLE
Save annotations separately

### DIFF
--- a/app.js
+++ b/app.js
@@ -140,24 +140,15 @@ app.use('/data', require('./controller/data/'));
 app.get('/api', function (req, res) {
     console.warn("call to GET api");
     var loggedUser = req.isAuthenticated()?req.user.username:"anonymous"; // eslint-disable-line no-unused-vars
-//    var data = [];
-//    var i;
     console.warn(req.query);
-    db.get('annotations').findOne({
-        source: req.query.source,
-        section: req.query.section,
+    db.get('annotations').find({
+        fileID: req.query.fileID,
+        user: loggedUser,
         backup: {$exists: false}
     })
     .then(function(obj) {
         if(obj) {
-
-            /*
-            for (i = 0; i < obj.length; i+=1) {
-                data.push(obj[i].annotation);
-            }
-            res.send(data);
-            */
-            res.send(obj.annotation);
+            res.send(obj);
         } else {
             res.send([]);
         }

--- a/app.js
+++ b/app.js
@@ -174,15 +174,21 @@ app.post('/api', function (req, res) {
                 multi:true
             })
             .then(function() {
+                var annotation_list = [];
+                var item;
+                var i;
+                var all_annotations = JSON.parse(req.body.annotation);
+                for( i = 0; i < all_annotations.Regions.length; i += 1) {
+                    item = {
+                        fileID: req.body.fileID,
+                        user: loggedUser,
+                        annotationHash: req.body.annotationHash,
+                        annotation: all_annotations.Regions[i]
+                    };
+                    annotation_list.push(item);
+                }
                 // insert new version
-                db.get('annotations').insert({
-                    source: req.body.source,
-                    user: loggedUser,
-                    section: req.body.section,
-//                    visibility: req.body.visibility,
-                    annotationHash: req.body.annotationHash,
-                    annotation: JSON.parse(req.body.annotation)
-                })
+                db.get('annotations').insert(annotation_list)
                 .then(() => { console.warn('success'); } )
                 .catch((err) => { console.error('error', err); } );
             });

--- a/public/js/microdraw.js
+++ b/public/js/microdraw.js
@@ -1432,9 +1432,6 @@ var Microdraw = (function () {
                 // post data to database
                 var pr = new Promise(function(resolve, reject) {
                     (function(sl2, h2) {
-                        if (typeof me.fileID === 'undefined') {
-                            me.fileID = me.source + '_' + sl2;
-                        }
                         $.ajax({
                             url:me.dbroot,
                             type:"POST",
@@ -1487,10 +1484,6 @@ var Microdraw = (function () {
             return new Promise(function(resolve, reject) {
                 if( me.debug ) {
                     console.log("> microdrawDBLoad promise");
-                }
-                // if no fileID given, set it to 'source_section'
-                if (typeof me.fileID === 'undefined') {
-                    me.fileID = me.source + "_" + me.section;
                 }
 
                 $.getJSON(me.dbroot, {
@@ -2345,6 +2338,11 @@ var Microdraw = (function () {
             me.currentImage = me.imageOrder[Math.floor(obj.tileSources.length / 2)];
 
             me.params.tileSources = obj.tileSources;
+            if (typeof obj.fileID !== 'undefined') {
+                me.fileID = obj.fileID;
+            } else {
+                me.fileID = me.source + '_' + me.section;
+            }
             me.viewer = new OpenSeadragon({
                 id: "openseadragon1",
                 prefixUrl: "lib/openseadragon/images/",

--- a/public/js/microdraw.js
+++ b/public/js/microdraw.js
@@ -1432,13 +1432,15 @@ var Microdraw = (function () {
                 // post data to database
                 var pr = new Promise(function(resolve, reject) {
                     (function(sl2, h2) {
+                        if (typeof me.fileID === 'undefined') {
+                            me.fileID = me.source + '_' + sl2;
+                        }
                         $.ajax({
                             url:me.dbroot,
                             type:"POST",
                             data: {
                                 action: "save",
-                                source: me.source,
-                                section: sl2,
+                                fileID: me.fileID,
                                 annotationHash: h2,
                                 annotation: JSON.stringify(value)
                             },
@@ -1486,11 +1488,14 @@ var Microdraw = (function () {
                 if( me.debug ) {
                     console.log("> microdrawDBLoad promise");
                 }
+                // if no fileID given, set it to 'source_section'
+                if (typeof me.fileID === 'undefined') {
+                    me.fileID = me.source + "_" + me.section;
+                }
 
                 $.getJSON(me.dbroot, {
                     action: "load_last",
-                    source: me.source,
-                    section: me.section
+                    fileID: me.fileID
                 }).success(function (data) {
                     var i, json, reg;
                     me.annotationLoadingFlag = false;
@@ -1524,11 +1529,11 @@ var Microdraw = (function () {
                     //obj = JSON.parse(data);
                     //obj = data;
                     //if( obj ) {
-                    for( i = 0; i < data.Regions.length; i += 1 ) {
+                    for( i = 0; i < data.length; i += 1 ) {
                         reg = {};
-                        reg.name = data.Regions[i].name;
-                        reg.page = data.Regions[i].page;
-                        json = data.Regions[i].path;
+                        reg.name = data[i].annotation.name;
+                        //reg.page = data[i].annotation.page;
+                        json = data[i].annotation.path;
                         reg.path = new paper.Path();
 
                         /** @todo Remove workaround once paperjs will be fixed */

--- a/public/test_data/cat.json
+++ b/public/test_data/cat.json
@@ -2,5 +2,6 @@
     "tileSources": [
         "test_data/cat.dzi"
     ],
-    "pixelsPerMeter": 10000
+    "pixelsPerMeter": 10000,
+    "fileID": "cat"
 }


### PR DESCRIPTION

I changed the microdrawDBSave and microdrawDBLoad methods and the /api requests, so that annotations are saved separately.

`fileID`was added as an Identifier for an image. It is currently generated from `source` and `section` but should be given in the json file.

- [ ] `screenshot_test_walk` generates the same test pictures as there were and does not show any errors
- [ ] These changes fix #64  (github issue number if applicable).
- [ ] All MicroDraw tools behave as expected:
    * **GESTURES**
        - [x] zoom in and out with two finger drag works
    * **KEYS**
        * right and up arrow key or left and down arrow key
            - [ ] jump to next or previous slice respectively
            - [ ] update the slider accordingly
            - [ ] update the slice number accordingly 
        * cmd z undoes
            - [ ] any step back that you have done in their chronological order including
            - [ ] translation of region
            - [ ] drawing region
            - [ ] adding point
            - [ ] deleting point
        to be completed (maybe it is implemented and working for all functions, so we can delete the single step checks)
    * **TOOL BUTTONS**
        * red rectangle in navigation window 
            - [ ] corresponds to tissue piece selected in viewer
            - [ ] can be navigated upon mouse down drag
        * navigation tool 
            - [x] navigates the slice inside the viewer upon mouse down drag
        * home button
            - [ ] zooms out to view the data in full screen size view
        * zoomIn tool
            - [ ] zooms one step in upon click
        * zoomOut tool
            - [ ] zooms one step out upon click
        * left arrow
            - [ ] jumps to the previous slice
        * right arrow
            - [ ] jumps to the next slice
        * select tool
            - [ ] selects a region upon click
        * draw tool
            - [ ] draws a new region as bezier curve
        * drawPolygon tool
            - [x] draws a new region as a polygon path
        * simplify tool
            - [ ] decreases the number of points in the region path while aiming at conserving the shape
        * addPoint tool
            - [ ] adds a point to the path upon click at position of mouse click
        * deletePoint tool
            - [ ] deletes a point from the path upon mouse click
        * addRegion tool
            - [ ] unifies two overlapping regions into one
        * deleteRegion tool
            - [ ] deletes a region upon click
        * splitRegion tool
            - [ ] splits one region at the intersection path with a second region
        * rotate tool
            - [ ] rotates a region around the point of mouse click
        * flip tool
            - [ ] flips a region around its vertical axis
        * toPolygon tool
            - [ ] converts the region path from bezier curve to polygon path
        * toBezier
            - [ ] converts the region path from polygon path to bezier curve
        * copy tool
            - [ ] copies a region
        * paste tool
            - [ ] pastes the copied region
        * save tool
            - [x] saves the set of drawn regions to the database
        * screenshot tool
            - [ ] creates a screenshot of the data layer (not of the annotations yet) at a chosen resolution
        * delete tool
            - [ ] deletes the selected region
        * closeMenu tool
            - [ ] hides the menu bar upon click
        * openMenu tool
            - [ ] shows the menu bar upon click
        * undo tool
            - [ ] undoes the user's actions in reverse chronological order
        
            
<!-- Either: -->
- [ ] I implemented tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Again, many many thanks for your work! \ö/ -->

