### PR TITLE
Ported the remaining tools to external JS

### DIFF
--- a/public/js/microdraw.js
+++ b/public/js/microdraw.js
@@ -714,81 +714,6 @@ var Microdraw = (function () {
             me.handle = null;
 
             switch( me.selectedTool ) {
-                case "addPoint":
-                case "deletePoint":
-                case "addRegion":
-                case "delete": {
-                    hitResult = paper.project.hitTest(point, {
-                            tolerance: me.tolerance,
-                            stroke: true,
-                            segments: true,
-                            fill: true,
-                            handles: true
-                        });
-
-                    me.newRegionFlag = false;
-                    if( hitResult ) {
-                        var i, re;
-                        for( i = 0; i < me.ImageInfo[me.currentImage].Regions.length; i += 1 ) {
-                            if( me.ImageInfo[me.currentImage].Regions[i].path === hitResult.item ) {
-                                re = me.ImageInfo[me.currentImage].Regions[i];
-                                break;
-                            }
-                        }
-
-                        // select path
-                        if( me.region && me.region !== re ) {
-                            me.region.path.selected = false;
-                            prevRegion = me.region;
-                        }
-                        me.selectRegion(re);
-
-                        if( me.selectedTool === "deletePoint" ) {
-                            if( hitResult.type === 'segment' ) {
-                                hitResult.segment.remove();
-                                me.commitMouseUndo();
-                            }
-                        } else if( hitResult.type === 'stroke' && me.selectedTool === "addPoint" ) {
-                            me.region.path
-                            .curves[hitResult.location.index]
-                            .divide(hitResult.location);
-                            me.region.path.fullySelected = true;
-                            me.commitMouseUndo();
-                            paper.view.draw();
-                        } else if( me.selectedTool === "addRegion" ) {
-                            if( prevRegion ) {
-                                var newPath = me.region.path.unite(prevRegion.path);
-                                me.removeRegion(prevRegion);
-                                me.region.path.remove();
-                                me.region.path = newPath;
-                                me.updateRegionList();
-                                me.selectRegion(me.region);
-                                paper.view.draw();
-                                me.commitMouseUndo();
-                                me.backToSelect();
-                            }
-                        } else if( me.selectedTool === "delete" ) {
-                            if( prevRegion ) {
-                                var newPath = prevRegion.path.subtract(me.region.path);
-                                me.removeRegion(prevRegion);
-                                prevRegion.path.remove();
-                                me.newRegion({path:newPath});
-                                me.updateRegionList();
-                                me.selectRegion(me.region);
-                                paper.view.draw();
-                                me.commitMouseUndo();
-                                me.backToSelect();
-                            }
-                        }
-                        break;
-                    }
-                    if( hitResult === null && me.region ) {
-                        //deselect paths
-                        me.region.path.selected = false;
-                        me.region = null;
-                    }
-                    break;
-                }
                 case "rotate":
                     me.region.origin = point;
                     break;
@@ -796,6 +721,10 @@ var Microdraw = (function () {
                 /**
                  * @todo These are the tools that have been already encapsulated. When all tools will be encapsulated, the whole switch/case should be removed
                  */
+                case "delete":
+                case "addRegion":
+                case "addPoint":
+                case "deletePoint":
                 case "splitRegion":
                 case "drawPolygon":
                 case "drawLine":
@@ -1297,9 +1226,6 @@ var Microdraw = (function () {
             me.selectTool();
 
             switch(me.selectedTool) {
-                case "addPoint":
-                case "deletePoint":
-                case "addRegion":
                 case "rotate":
                     me.navEnabled = false;
                     me.handle = null;
@@ -1307,10 +1233,6 @@ var Microdraw = (function () {
                 case "navigate":
                     me.navEnabled = true;
                     me.handle = null;
-                    break;
-                case "delete":
-                    me.cmdDeleteSelected();
-                    me.backToPreviousTool(prevTool);
                     break;
                 case "save":
                     me.microdrawDBSave();
@@ -1356,6 +1278,9 @@ var Microdraw = (function () {
                 /**
                  * @todo These are the tools that have been already encapsulated. The switch/case should be removed when the encapsulation of all tools is finished
                  */
+                case "addRegion":
+                case "addPoint":
+                case "deletePoint":
                 case "flip":
                 case "draw":
                 case "drawPolygon":
@@ -1364,6 +1289,7 @@ var Microdraw = (function () {
                 case "toPolygon":
                 case "screenshot":
                 case "select":
+                case "delete":
                     me.tools[me.selectedTool].click(prevTool);
                     break;
             }

--- a/public/js/microdraw.js
+++ b/public/js/microdraw.js
@@ -713,26 +713,7 @@ var Microdraw = (function () {
 
             me.handle = null;
 
-            switch( me.selectedTool ) {
-                case "rotate":
-                    me.region.origin = point;
-                    break;
-
-                /**
-                 * @todo These are the tools that have been already encapsulated. When all tools will be encapsulated, the whole switch/case should be removed
-                 */
-                case "delete":
-                case "addRegion":
-                case "addPoint":
-                case "deletePoint":
-                case "splitRegion":
-                case "drawPolygon":
-                case "drawLine":
-                case "draw":
-                case "select":
-                    me.tools[me.selectedTool].mouseDown(point);
-                    break;
-            }
+            me.tools[me.selectedTool].mouseDown(point);
             paper.view.draw();
         },
 
@@ -758,32 +739,13 @@ var Microdraw = (function () {
             dpoint.y -= orig.y;
 
             if(me.tools[me.selectedTool] && me.tools[me.selectedTool].mouseDrag) {
-                me.tools[me.selectedTool].mouseDrag(point);
+                me.tools[me.selectedTool].mouseDrag(point,dpoint);
             } else if( me.handle ) {
                 me.handle.x += point.x-me.handle.point.x;
                 me.handle.y += point.y-me.handle.point.y;
                 me.handle.point = point;
                 me.commitMouseUndo();
-            } else if( me.selectedTool === "select" ) {
-                // event.stopHandlers = true;
-                for( var reg of me.ImageInfo[me.currentImage].Regions ) {
-                    if( reg.path.selected ) {
-                        reg.path.position.x += dpoint.x;
-                        reg.path.position.y += dpoint.y;
-                        me.commitMouseUndo();
-                    }
-                }
-            }
-            if( me.selectedTool === "rotate" ) {
-                event.stopHandlers = true;
-                var degree = parseInt(dpoint.x, 10);
-                for( i in me.ImageInfo[me.currentImage].Regions ) {
-                    if( me.ImageInfo[me.currentImage].Regions[i].path.selected ) {
-                        me.ImageInfo[me.currentImage].Regions[i].path.rotate(degree, me.region.origin);
-                        me.commitMouseUndo();
-                    }
-                }
-            }
+            } 
             paper.view.draw();
         },
 
@@ -1225,74 +1187,8 @@ var Microdraw = (function () {
             me.selectedTool = $(this).attr("id");
             me.selectTool();
 
-            switch(me.selectedTool) {
-                case "rotate":
-                    me.navEnabled = false;
-                    me.handle = null;
-                    break;
-                case "navigate":
-                    me.navEnabled = true;
-                    me.handle = null;
-                    break;
-                case "save":
-                    me.microdrawDBSave();
-                    me.backToPreviousTool(prevTool);
-                    break;
-                case "zoomIn":
-                case "zoomOut":
-                case "home":
-                    me.backToPreviousTool(prevTool);
-                    break;
-                case "previous":
-                    me.loadPreviousImage();
-                    me.backToPreviousTool(prevTool);
-                    break;
-                case "next":
-                    me.loadNextImage();
-                    me.backToPreviousTool(prevTool);
-                    break;
-                case "copy":
-                    me.cmdCopy();
-                    //me.backToPreviousTool(prevTool);
-                    me.backToSelect();
-                    break;
-                case "paste":
-                    me.cmdPaste();
-                    //me.backToPreviousTool(prevTool);
-                    me.backToSelect();
-                    break;
-                case "simplify":
-                    me.simplify(me.region);
-                    //me.backToPreviousTool(prevTool);
-                    me.backToSelect();
-                    break;
-                case "closeMenu":
-                    me.toggleMenu();
-                    me.backToPreviousTool(prevTool);
-                    break;
-                case "openMenu":
-                    me.toggleMenu();
-                    me.backToPreviousTool(prevTool);
-                    break;
-
-                /**
-                 * @todo These are the tools that have been already encapsulated. The switch/case should be removed when the encapsulation of all tools is finished
-                 */
-                case "addRegion":
-                case "addPoint":
-                case "deletePoint":
-                case "flip":
-                case "draw":
-                case "drawPolygon":
-                case "drawLine":
-                case "toBezier":
-                case "toPolygon":
-                case "screenshot":
-                case "select":
-                case "delete":
-                    me.tools[me.selectedTool].click(prevTool);
-                    break;
-            }
+            if( me.tools[me.selectedTool] )
+                me.tools[me.selectedTool].click()
         },
 
         /**

--- a/public/js/microdraw.js
+++ b/public/js/microdraw.js
@@ -713,7 +713,7 @@ var Microdraw = (function () {
 
             me.handle = null;
 
-            me.tools[me.selectedTool].mouseDown(point);
+            if( me.tools[me.selectedTool].mouseDown ) me.tools[me.selectedTool].mouseDown(point);
             paper.view.draw();
         },
 
@@ -737,15 +737,14 @@ var Microdraw = (function () {
             var dpoint = paper.view.viewToProject(new paper.Point(dx, dy));
             dpoint.x -= orig.x;
             dpoint.y -= orig.y;
-
-            if(me.tools[me.selectedTool] && me.tools[me.selectedTool].mouseDrag) {
-                me.tools[me.selectedTool].mouseDrag(point,dpoint);
-            } else if( me.handle ) {
+            if( me.handle ) {
                 me.handle.x += point.x-me.handle.point.x;
                 me.handle.y += point.y-me.handle.point.y;
                 me.handle.point = point;
                 me.commitMouseUndo();
-            } 
+            } else if (me.tools[me.selectedTool] && me.tools[me.selectedTool].mouseDrag) {
+                me.tools[me.selectedTool].mouseDrag(point,dpoint);
+            }  
             paper.view.draw();
         },
 

--- a/public/js/microdraw.js
+++ b/public/js/microdraw.js
@@ -713,7 +713,7 @@ var Microdraw = (function () {
 
             me.handle = null;
 
-            if( me.tools[me.selectedTool].mouseDown ) me.tools[me.selectedTool].mouseDown(point);
+            if( me.tools[me.selectedTool] && me.tools[me.selectedTool].mouseDown ) me.tools[me.selectedTool].mouseDown(point);
             paper.view.draw();
         },
 
@@ -756,9 +756,7 @@ var Microdraw = (function () {
             if( me.debug ) {
                 console.log("> mouseUp");
             }
-            if(me.tools[me.selectedTool] && me.tools[me.selectedTool].mouseUp) {
-                me.tools[me.selectedTool].mouseUp();
-            }
+            if(me.tools[me.selectedTool] && me.tools[me.selectedTool].mouseUp) me.tools[me.selectedTool].mouseUp();
         },
 
         /**
@@ -1186,8 +1184,7 @@ var Microdraw = (function () {
             me.selectedTool = $(this).attr("id");
             me.selectTool();
 
-            if( me.tools[me.selectedTool] )
-                me.tools[me.selectedTool].click()
+            if( me.tools[me.selectedTool] && me.tools[me.selectedTool].click ) me.tools[me.selectedTool].click()
         },
 
         /**

--- a/public/js/tools/addPoint.js
+++ b/public/js/tools/addPoint.js
@@ -62,4 +62,6 @@ var ToolAddPoint = { addPoint : (function(){
             Microdraw.handle = null;
         }
     }
-})}
+    
+    return tool;
+}())}

--- a/public/js/tools/addPoint.js
+++ b/public/js/tools/addPoint.js
@@ -1,0 +1,65 @@
+/*global Microdraw*/
+/*global paper*/
+
+var ToolAddPoint = { draw : (function(){
+    var tool = {
+
+        /**
+         * @function mouseDown
+         * @param {object} point The point where you clicked (x,y)
+         * @returns {void}
+         */
+        mouseDown : function mouseDown(point) {
+            var hitResult = paper.project.hitTest(point, {
+                tolerance : Microdraw.tolerance,
+                stroke : true,
+                segments : true,
+                fill : true,
+                handles : true
+            })
+            Microdraw.newRegionFlag = false;
+            
+            if( hitResult ) {
+                var i, re;
+                for( i = 0; i < Microdraw.ImageInfo[Microdraw.currentImage].Regions.length; i += 1 ) {
+                    if( Microdraw.ImageInfo[Microdraw.currentImage].Regions[i].path === hitResult.item ) {
+                        re = Microdraw.ImageInfo[Microdraw.currentImage].Regions[i];
+                        break;
+                    }
+                }
+
+                // select path
+                if( Microdraw.region && Microdraw.region !== re ) {
+                    Microdraw.region.path.selected = false;
+                    prevRegion = Microdraw.region;
+                }
+                Microdraw.selectRegion(re);
+
+                if( hitResult.type === 'stroke'){
+                    Microdraw.region.path
+                        .curves[hitResult.location.index]
+                        .divide(hitResult.location);
+                        Microdraw.region.path.fullySelected = true;
+                        Microdraw.commitMouseUndo();
+                };
+            } else {
+                if( Microdraw.region ){
+                    Microdraw.region.path.selected = false
+                    Microdraw.region = null
+                };
+            };
+            paper.view.draw();
+        },
+
+        /**
+         * @function click
+         * @desc add an additional point to the selected annotation
+         * @param {string} prevTool The previous tool to which the selection goes back
+         * @returns {void}
+         */
+        click : function click(prevTool) {
+            Microdraw.navEnabled = false;
+            Microdraw.handle = null;
+        }
+    }
+})}

--- a/public/js/tools/addRegion.js
+++ b/public/js/tools/addRegion.js
@@ -61,4 +61,6 @@ var ToolAddRegion = { addRegion : (function(){
             Microdraw.handle = null;
         }
     }
-})}
+    
+    return tool;
+}())}

--- a/public/js/tools/closeMenu.js
+++ b/public/js/tools/closeMenu.js
@@ -1,0 +1,20 @@
+/*global Microdraw*/
+/*global paper*/
+
+var ToolCloseMenu = { closeMenu : (function(){
+    var tool = {
+
+        /**
+         * @function click
+         * @desc closeMenu. close the side menu
+         * @param {string} prevTool The previous tool to which the selection goes back
+         * @returns {void}
+         */
+        click : function click(prevTool) {
+            Microdraw.toggleMenu();
+            Microdraw.backToPreviousTool(prevTool);
+        }
+    }
+    
+    return tool;
+}())}

--- a/public/js/tools/copy.js
+++ b/public/js/tools/copy.js
@@ -1,0 +1,20 @@
+/*global Microdraw*/
+/*global paper*/
+
+var ToolCopy = { copy : (function(){
+    var tool = {
+
+        /**
+         * @function click
+         * @desc copy. Copy selected annotation
+         * @param {string} prevTool The previous tool to which the selection goes back
+         * @returns {void}
+         */
+        click : function click(prevTool) {
+            Microdraw.cmdCopy();
+            Microdraw.backToSelect();
+        }
+    }
+    
+    return tool;
+}())}

--- a/public/js/tools/delete.js
+++ b/public/js/tools/delete.js
@@ -62,5 +62,7 @@ var ToolDelete = { delete : (function(){
             Microdraw.cmdDeleteSelected();
             Microdraw.backToPreviousTool(prevTool);
         }
-    }
-})}
+    };
+
+    return tool;
+}())}

--- a/public/js/tools/delete.js
+++ b/public/js/tools/delete.js
@@ -4,54 +4,6 @@
 var ToolDelete = { delete : (function(){
     var tool = {
 
-        /* TODO: mouseDown of delete will never be called (?) */
-        
-        /**
-         * @function mouseDown
-         * @param {object} point The point where you clicked (x,y)
-         * @returns {void}
-         */
-        mouseDown : function mouseDown(point) {
-            var hitResult = paper.project.hitTest(point, {
-                tolerance : Microdraw.tolerance,
-                stroke : true,
-                segments : true,
-                fill : true,
-                handles : true
-            })
-            Microdraw.newRegionFlag = false;
-            
-            if( hitResult ) {
-                var re = Microdraw.ImageInfo[Microdraw.currentImage].Regions.find(region=>region.path === hitResult.item)
-                
-                // select path
-                var prevRegion
-                if( Microdraw.region && Microdraw.region !== re ) {
-                    Microdraw.region.path.selected = false;
-                    prevRegion = Microdraw.region;
-                }
-                Microdraw.selectRegion(re);
-
-                if( prevRegion ) {
-                    var newPath = prevRegion.path.subtract(Microdraw.region.path);
-                    Microdraw.removeRegion(prevRegion);
-                    prevRegion.path.remove();
-                    Microdraw.newRegion({path:newPath});
-                    Microdraw.updateRegionList();
-                    Microdraw.selectRegion(Microdraw.region);
-                    paper.view.draw();
-                    Microdraw.commitMouseUndo();
-                    Microdraw.backToSelect();
-                }
-            } else {
-                if( Microdraw.region ){
-                    Microdraw.region.path.selected = false
-                    Microdraw.region = null
-                };
-            };
-            paper.view.draw();
-        },
-
         /**
          * @function click
          * @desc add an additional point to the selected annotation

--- a/public/js/tools/delete.js
+++ b/public/js/tools/delete.js
@@ -1,9 +1,11 @@
 /*global Microdraw*/
 /*global paper*/
 
-var ToolAddPoint = { addPoint : (function(){
+var ToolDelete = { delete : (function(){
     var tool = {
 
+        /* TODO: mouseDown of delete will never be called (?) */
+        
         /**
          * @function mouseDown
          * @param {object} point The point where you clicked (x,y)
@@ -20,28 +22,27 @@ var ToolAddPoint = { addPoint : (function(){
             Microdraw.newRegionFlag = false;
             
             if( hitResult ) {
-                var i, re;
-                for( i = 0; i < Microdraw.ImageInfo[Microdraw.currentImage].Regions.length; i += 1 ) {
-                    if( Microdraw.ImageInfo[Microdraw.currentImage].Regions[i].path === hitResult.item ) {
-                        re = Microdraw.ImageInfo[Microdraw.currentImage].Regions[i];
-                        break;
-                    }
-                }
-
+                var re = Microdraw.ImageInfo[Microdraw.currentImage].Regions.find(region=>region.path === hitResult.item)
+                
                 // select path
+                var prevRegion
                 if( Microdraw.region && Microdraw.region !== re ) {
                     Microdraw.region.path.selected = false;
                     prevRegion = Microdraw.region;
                 }
                 Microdraw.selectRegion(re);
 
-                if( hitResult.type === 'stroke'){
-                    Microdraw.region.path
-                        .curves[hitResult.location.index]
-                        .divide(hitResult.location);
-                        Microdraw.region.path.fullySelected = true;
-                        Microdraw.commitMouseUndo();
-                };
+                if( prevRegion ) {
+                    var newPath = prevRegion.path.subtract(Microdraw.region.path);
+                    Microdraw.removeRegion(prevRegion);
+                    prevRegion.path.remove();
+                    Microdraw.newRegion({path:newPath});
+                    Microdraw.updateRegionList();
+                    Microdraw.selectRegion(Microdraw.region);
+                    paper.view.draw();
+                    Microdraw.commitMouseUndo();
+                    Microdraw.backToSelect();
+                }
             } else {
                 if( Microdraw.region ){
                     Microdraw.region.path.selected = false
@@ -58,8 +59,8 @@ var ToolAddPoint = { addPoint : (function(){
          * @returns {void}
          */
         click : function click(prevTool) {
-            Microdraw.navEnabled = false;
-            Microdraw.handle = null;
+            Microdraw.cmdDeleteSelected();
+            Microdraw.backToPreviousTool(prevTool);
         }
     }
 })}

--- a/public/js/tools/deletePoint.js
+++ b/public/js/tools/deletePoint.js
@@ -37,7 +37,7 @@ var ToolDeletePoint = { deletePoint : (function(){
 
                 if( hitResult.type === 'segment' ) {
                     hitResult.segment.remove();
-                    me.commitMouseUndo();
+                    Microdraw.commitMouseUndo();
                 }
             } else {
                 if( Microdraw.region ){
@@ -58,5 +58,8 @@ var ToolDeletePoint = { deletePoint : (function(){
             Microdraw.navEnabled = false;
             Microdraw.handle = null;
         }
-    }
-})}
+    };
+
+
+    return tool;
+}())}

--- a/public/js/tools/deletePoint.js
+++ b/public/js/tools/deletePoint.js
@@ -1,7 +1,7 @@
 /*global Microdraw*/
 /*global paper*/
 
-var ToolAddPoint = { addPoint : (function(){
+var ToolDeletePoint = { deletePoint : (function(){
     var tool = {
 
         /**
@@ -35,13 +35,10 @@ var ToolAddPoint = { addPoint : (function(){
                 }
                 Microdraw.selectRegion(re);
 
-                if( hitResult.type === 'stroke'){
-                    Microdraw.region.path
-                        .curves[hitResult.location.index]
-                        .divide(hitResult.location);
-                        Microdraw.region.path.fullySelected = true;
-                        Microdraw.commitMouseUndo();
-                };
+                if( hitResult.type === 'segment' ) {
+                    hitResult.segment.remove();
+                    me.commitMouseUndo();
+                }
             } else {
                 if( Microdraw.region ){
                     Microdraw.region.path.selected = false

--- a/public/js/tools/draw.js
+++ b/public/js/tools/draw.js
@@ -56,6 +56,7 @@ var ToolDraw = { draw: (function () {
             if( Microdraw.newRegionFlag === true ) {
                 Microdraw.region.path.closed = true;
                 Microdraw.region.path.fullySelected = true;
+                Microdraw.newRegionFlag = false
 
                 // to delete all unnecessary segments while preserving the form of the
                 // region to make it modifiable; & adding handles to the segments

--- a/public/js/tools/draw.js
+++ b/public/js/tools/draw.js
@@ -40,10 +40,11 @@ var ToolDraw = { draw: (function () {
 
         /**
          * @function mouseDrag
-         * @param {object} point The point where you click (x,y)
+         * @param {object} point The point where you moved to (x,y)
+         * @param {object} dpoint The movement of the point
          * @return {void}
         */
-        mouseDrag: function mouseDrag(point) {
+        mouseDrag: function mouseDrag(point,dpoint) {
             Microdraw.region.path.add(point);
         },
 

--- a/public/js/tools/draw.js
+++ b/public/js/tools/draw.js
@@ -89,7 +89,7 @@ var ToolDraw = { draw: (function () {
             paper.view.draw();
         },
 
-        /*
+        /**
         * @function click
         * @desc Convert polygon path to bezier curve
         * @param {string} prevTool The previous tool to which the selection goes back

--- a/public/js/tools/drawLine.js
+++ b/public/js/tools/drawLine.js
@@ -25,9 +25,11 @@ var ToolDrawLine = {
 
             /**
              * @function mouseDrag
-             * @param {object} point The point where you click (x,y)
+             * @param {object} point The point where you moved to (x,y)
+             * @param {object} dpoint The movement of the point
+             * @return {void}
             */
-            mouseDrag: function mouseDrag(point) {
+            mouseDrag: function mouseDrag(point,dpoint) {
                 Microdraw.region.path.add(point);
             },
 

--- a/public/js/tools/home.js
+++ b/public/js/tools/home.js
@@ -1,0 +1,19 @@
+/*global Microdraw*/
+/*global paper*/
+
+var ToolHome = { home : (function(){
+    var tool = {
+
+        /**
+         * @function click
+         * @desc home. Openseadragon initialisation parameter binds the function.
+         * @param {string} prevTool The previous tool to which the selection goes back
+         * @returns {void}
+         */
+        click : function click(prevTool) {
+            Microdraw.backToPreviousTool(prevTool);
+        }
+    }
+    
+    return tool;
+}())}

--- a/public/js/tools/navigate.js
+++ b/public/js/tools/navigate.js
@@ -1,0 +1,20 @@
+/*global Microdraw*/
+/*global paper*/
+
+var ToolNavigate = { navigate : (function(){
+    var tool = {
+
+        /**
+         * @function click
+         * @desc navigate the canvas
+         * @param {string} prevTool The previous tool to which the selection goes back
+         * @returns {void}
+         */
+        click : function click(prevTool) {
+            Microdraw.navEnabled = false;
+            Microdraw.handle = null;
+        }
+    }
+    
+    return tool;
+}())}

--- a/public/js/tools/navigate.js
+++ b/public/js/tools/navigate.js
@@ -11,7 +11,7 @@ var ToolNavigate = { navigate : (function(){
          * @returns {void}
          */
         click : function click(prevTool) {
-            Microdraw.navEnabled = false;
+            Microdraw.navEnabled = true;
             Microdraw.handle = null;
         }
     }

--- a/public/js/tools/next.js
+++ b/public/js/tools/next.js
@@ -1,0 +1,20 @@
+/*global Microdraw*/
+/*global paper*/
+
+var ToolNext = { next : (function(){
+    var tool = {
+
+        /**
+         * @function click
+         * @desc next. Next image.
+         * @param {string} prevTool The previous tool to which the selection goes back
+         * @returns {void}
+         */
+        click : function click(prevTool) {
+            Microdraw.loadNextImage();
+            Microdraw.backToPreviousTool(prevTool);
+        }
+    }
+    
+    return tool;
+}())}

--- a/public/js/tools/openMenu.js
+++ b/public/js/tools/openMenu.js
@@ -1,0 +1,20 @@
+/*global Microdraw*/
+/*global paper*/
+
+var ToolCloseMenu = { closeMenu : (function(){
+    var tool = {
+
+        /**
+         * @function click
+         * @desc closeMenu. close the side menu
+         * @param {string} prevTool The previous tool to which the selection goes back
+         * @returns {void}
+         */
+        click : function click(prevTool) {
+            Microdraw.toggleMenu();
+            Microdraw.backToPreviousTool(prevTool);
+        }
+    }
+    
+    return tool;
+}())}

--- a/public/js/tools/paste.js
+++ b/public/js/tools/paste.js
@@ -1,0 +1,20 @@
+/*global Microdraw*/
+/*global paper*/
+
+var ToolPaste = { paste : (function(){
+    var tool = {
+
+        /**
+         * @function click
+         * @desc paste. Paste selected annotation
+         * @param {string} prevTool The previous tool to which the selection goes back
+         * @returns {void}
+         */
+        click : function click(prevTool) {
+            Microdraw.cmdPaste();
+            Microdraw.backToSelect();
+        }
+    }
+    
+    return tool;
+}())}

--- a/public/js/tools/previous.js
+++ b/public/js/tools/previous.js
@@ -1,0 +1,20 @@
+/*global Microdraw*/
+/*global paper*/
+
+var ToolPrevious = { previous : (function(){
+    var tool = {
+
+        /**
+         * @function click
+         * @desc previous. Previous image.
+         * @param {string} prevTool The previous tool to which the selection goes back
+         * @returns {void}
+         */
+        click : function click(prevTool) {
+            Microdraw.loadPreviousImage();
+            Microdraw.backToPreviousTool(prevTool);
+        }
+    }
+    
+    return tool;
+}())}

--- a/public/js/tools/rotate.js
+++ b/public/js/tools/rotate.js
@@ -12,7 +12,7 @@ var ToolRotate = { rotate : (function(){
          */
         mouseDrag : function mouseDrag(point,dpoint) {
             event.stopHandlers = true;
-            var degree = parseInt(point.x - dpoint.x, 10);
+            var degree = parseInt(dpoint.x, 10);
             for( i in Microdraw.ImageInfo[Microdraw.currentImage].Regions ) {
                 if( Microdraw.ImageInfo[Microdraw.currentImage].Regions[i].path.selected ) {
                     Microdraw.ImageInfo[Microdraw.currentImage].Regions[i].path.rotate(degree, Microdraw.region.origin);

--- a/public/js/tools/rotate.js
+++ b/public/js/tools/rotate.js
@@ -1,0 +1,46 @@
+/*global Microdraw*/
+/*global paper*/
+
+var ToolRotate = { rotate : (function(){
+    var tool = {
+
+        /**
+         * @function mouseDrag
+         * @param {object} point The point where you moved to (x,y)
+         * @param {object} dpoint The movement of the point
+         * @return {void}
+         */
+        mouseDrag : function mouseDrag(point,dpoint) {
+            event.stopHandlers = true;
+            var degree = parseInt(point.x - dpoint.x, 10);
+            for( i in Microdraw.ImageInfo[Microdraw.currentImage].Regions ) {
+                if( Microdraw.ImageInfo[Microdraw.currentImage].Regions[i].path.selected ) {
+                    Microdraw.ImageInfo[Microdraw.currentImage].Regions[i].path.rotate(degree, Microdraw.region.origin);
+                    Microdraw.commitMouseUndo();
+                }
+            }
+        },
+
+        /**
+         * @function mouseDown
+         * @param {object} point The point where you clicked (x,y), will be the centre of rotation
+         * @returns {void}
+         */
+        mouseDown : function mouseDown(point) {
+            Microdraw.region.origin = point;
+        },
+
+        /**
+         * @function click
+         * @desc rotate the selected annotation
+         * @param {string} prevTool The previous tool to which the selection goes back
+         * @returns {void}
+         */
+        click : function click(prevTool) {
+            Microdraw.navEnabled = false;
+            Microdraw.handle = null;
+        }
+    }
+    
+    return tool;
+}())}

--- a/public/js/tools/save.js
+++ b/public/js/tools/save.js
@@ -1,0 +1,20 @@
+/*global Microdraw*/
+/*global paper*/
+
+var ToolSave = { save : (function(){
+    var tool = {
+
+        /**
+         * @function click
+         * @desc save the annotations
+         * @param {string} prevTool The previous tool to which the selection goes back
+         * @returns {void}
+         */
+        click : function click(prevTool) {
+            Microdraw.microdrawDBSave();
+            Microdraw.backToPreviousTool(prevTool);
+        }
+    }
+    
+    return tool;
+}())}

--- a/public/js/tools/select.js
+++ b/public/js/tools/select.js
@@ -6,6 +6,23 @@ var ToolSelect = {select: (function() {
     var tool = {
 
         /**
+         * @function mouseDrag
+         * @param {object} point The point where you moved to (x,y)
+         * @param {object} dpoint The movement of the point
+         * @return {void}
+        */
+        mouseDrag: function mouseDrag(point,dpoint) {
+            // event.stopHandlers = true;
+            for( var reg of Microdraw.ImageInfo[Microdraw.currentImage].Regions ) {
+                if( reg.path.selected ) {
+                    reg.path.position.x += dpoint.x;
+                    reg.path.position.y += dpoint.y;
+                    Microdraw.commitMouseUndo();
+                }
+            }
+        },
+
+        /**
          * @function mouseDown
          * @param {object} point The point where you click (x,y)
          * @returns {void}

--- a/public/js/tools/simplify.js
+++ b/public/js/tools/simplify.js
@@ -1,0 +1,20 @@
+/*global Microdraw*/
+/*global paper*/
+
+var ToolSimplify = { simplify : (function(){
+    var tool = {
+
+        /**
+         * @function click
+         * @desc simplify. Simplify the selected path.
+         * @param {string} prevTool The previous tool to which the selection goes back
+         * @returns {void}
+         */
+        click : function click(prevTool) {
+            Microdraw.simplify(Microdraw.region);
+            Microdraw.backToSelect();
+        }
+    }
+    
+    return tool;
+}())}

--- a/public/js/tools/subtractRegion.js
+++ b/public/js/tools/subtractRegion.js
@@ -1,7 +1,7 @@
 /*global Microdraw*/
 /*global paper*/
 
-var ToolAddRegion = { addRegion : (function(){
+var ToolSubtractRegion = { subtractRegion : (function(){
     var tool = {
 
         /**
@@ -31,7 +31,7 @@ var ToolAddRegion = { addRegion : (function(){
                 Microdraw.selectRegion(re);
 
                 if( prevRegion ) {
-                    var newPath = Microdraw.region.path.unite(prevRegion.path);
+                    var newPath = Microdraw.region.path.subtract(prevRegion.path);
                     Microdraw.removeRegion(prevRegion);
                     Microdraw.region.path.remove();
                     Microdraw.region.path = newPath;

--- a/public/js/tools/zoomIn.js
+++ b/public/js/tools/zoomIn.js
@@ -1,0 +1,19 @@
+/*global Microdraw*/
+/*global paper*/
+
+var ToolZoomIn = { zoomIn : (function(){
+    var tool = {
+
+        /**
+         * @function click
+         * @desc zoomIn. Openseadragon initialisation parameter binds the function.
+         * @param {string} prevTool The previous tool to which the selection goes back
+         * @returns {void}
+         */
+        click : function click(prevTool) {
+            Microdraw.backToPreviousTool(prevTool);
+        }
+    }
+    
+    return tool;
+}())}

--- a/public/js/tools/zoomOut.js
+++ b/public/js/tools/zoomOut.js
@@ -1,0 +1,19 @@
+/*global Microdraw*/
+/*global paper*/
+
+var ToolZoomOut = { zoomOut : (function(){
+    var tool = {
+
+        /**
+         * @function click
+         * @desc zoomOut. Openseadragon initialisation parameter binds the function.
+         * @param {string} prevTool The previous tool to which the selection goes back
+         * @returns {void}
+         */
+        click : function click(prevTool) {
+            Microdraw.backToPreviousTool(prevTool);
+        }
+    }
+    
+    return tool;
+}())}


### PR DESCRIPTION
<!-- Thank you so much for your contribution to MicroDraw! <3 -->

<!-- Please find a short title for your pull request and describe your changes on the following line: -->
Exported the remaining tools to external JS files

---
<!-- Please go through our check list and replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `screenshot_test_walk` generates the same test pictures as there were and does not show any errors
- [x] These changes fix #75  (github issue number if applicable).
- [x] All MicroDraw tools behave as expected:
    * **GESTURES**
        - [ ] zoom in and out with two finger drag works
    * **KEYS**
        * right and up arrow key or left and down arrow key
            - [ ] jump to next or previous slice respectively
            - [ ] update the slider accordingly
            - [ ] update the slice number accordingly 
        * cmd z undoes
            - [x] any step back that you have done in their chronological order including
            - [x] translation of region
            - [x] drawing region
            - [x] adding point
            - [x] deleting point
        to be completed (maybe it is implemented and working for all functions, so we can delete the single step checks)
    * **TOOL BUTTONS**
        * red rectangle in navigation window 
            - [x] corresponds to tissue piece selected in viewer
            - [x] can be navigated upon mouse down drag
        * navigation tool 
            - [x] navigates the slice inside the viewer upon mouse down drag
        * home button
            - [x] zooms out to view the data in full screen size view
        * zoomIn tool
            - [x] zooms one step in upon click
        * zoomOut tool
            - [x] zooms one step out upon click
        * left arrow
            - [ ] jumps to the previous slice
        * right arrow
            - [ ] jumps to the next slice
        * select tool
            - [x] selects a region upon click
        * draw tool
            - [x] draws a new region as bezier curve
        * drawPolygon tool
            - [x] draws a new region as a polygon path
        * simplify tool
            - [x] decreases the number of points in the region path while aiming at conserving the shape
        * addPoint tool
            - [x] adds a point to the path upon click at position of mouse click
        * deletePoint tool
            - [x] deletes a point from the path upon mouse click
        * addRegion tool
            - [x] unifies two overlapping regions into one
        * deleteRegion tool
            - [x] deletes a region upon click
        * splitRegion tool
            - [ ] splits one region at the intersection path with a second region
        * rotate tool
            - [x] rotates a region around the point of mouse click
        * flip tool
            - [x] flips a region around its vertical axis
        * toPolygon tool
            - [x] converts the region path from bezier curve to polygon path
        * toBezier
            - [x] converts the region path from polygon path to bezier curve
        * copy tool
            - [x] copies a region
        * paste tool
            - [x] pastes the copied region
        * save tool
            - [ ] saves the set of drawn regions to the database
        * screenshot tool
            - [ ] creates a screenshot of the data layer (not of the annotations yet) at a chosen resolution
        * delete tool
            - [x] deletes the selected region
        * closeMenu tool
            - [ ] hides the menu bar upon click
        * openMenu tool
            - [ ] shows the menu bar upon click
        * undo tool
            - [x] undoes the user's actions in reverse chronological order
        
            
<!-- Either: -->
- [ ] I implemented tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Again, many many thanks for your work! \ö/ -->

