### PR TITLE
fixes #107, fixes slider style, fixes left and right arrow when secti…

### DIFF
--- a/app/public/js/microdraw.js
+++ b/app/public/js/microdraw.js
@@ -1612,7 +1612,7 @@ var Microdraw = (function () {
                 if( me.shortCuts[key] ) {
                     var shortcut = me.shortCuts[key];
                     shortcut();
-                    e.preventDefault();
+                    e.stopPropagation();
                 }
             });
         },
@@ -1749,7 +1749,7 @@ var Microdraw = (function () {
                     me.loadImage(me.imageOrder[index]);
                 }
             }
-            event.preventDefault(); // prevent the default action (scroll / move caret)
+            event.stopPropagation(); // prevent the default action (scroll / move caret)
         },
 
 
@@ -1959,7 +1959,7 @@ var Microdraw = (function () {
             me.selectTool();
 
             // Change current section by typing in the section number and pessing the enter key
-            $("#sectionName").keyup(me.sectionNameOnEnter);
+            $("#sectionName").keydown(me.sectionNameOnEnter);
 
             // Show and hide menu
             if( me.config.hideToolbar ) {

--- a/app/views/data.mustache
+++ b/app/views/data.mustache
@@ -53,7 +53,7 @@
                     <img class="button" id="zoomOut"        title="Zoom out"               src="img/zoomOut.svg" />
                     <div class="section-nav">
                         <img class="button" id="previous"   title="Previous section"         src="img/previous.svg" />
-                        <input id="sectionName" list="section-names" style="width:80px" />
+                        <input id="sectionName" list="section-names" style="width:65px;color:black" />
                         <img class="button" id="next"       title="Next section"             src="img/next.svg" />
                     </div>
                     <input type="range" id="slider" />


### PR DESCRIPTION
…on name input is in focus

<!-- Thank you so much for your contribution to MicroDraw! <3 -->

Fixes the below behaviours:
- image number text input text color = background color = white
- image number text input size slightly too large
- left and right arrow key bound to both image navigation and viewer pan #107 
- when image number text input is in focus, left and right arrow does not move the text caret, but instead navigate image and viewer pan

<!-- Please find a short title for your pull request and describe your changes on the following line: -->


---
<!-- Please go through our check list and replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `screenshot_test_walk` generates the same test pictures as there were and does not show any errors
- [x] These changes fix #107  (github issue number if applicable).
- [x] All MicroDraw tools behave as expected:
    * **GESTURES**
        - [ ] zoom in and out with two finger drag works
    * **KEYS**
        * right and up arrow key or left and down arrow key
            - [ ] jump to next or previous slice respectively
            - [ ] update the slider accordingly
            - [ ] update the slice number accordingly
        * cmd z undoes
            - [ ] any step back that you have done in their chronological order including
            - [ ] translation of region
            - [ ] drawing region
            - [ ] adding point
            - [ ] deleting point
        to be completed (maybe it is implemented and working for all functions, so we can delete the single step checks)
    * **TOOL BUTTONS**
        * red rectangle in navigation window
            - [ ] corresponds to tissue piece selected in viewer
            - [ ] can be navigated upon mouse down drag
        * navigation tool
            - [ ] navigates the slice inside the viewer upon mouse down drag
        * home button
            - [ ] zooms out to view the data in full screen size view
        * zoomIn tool
            - [ ] zooms one step in upon click
        * zoomOut tool
            - [ ] zooms one step out upon click
        * left arrow
            - [ ] jumps to the previous slice
        * right arrow
            - [ ] jumps to the next slice
        * select tool
            - [ ] selects a region upon click
        * draw tool
            - [ ] draws a new region as bezier curve
        * drawPolygon tool
            - [x] draws a new region as a polygon path
        * simplify tool
            - [ ] decreases the number of points in the region path while aiming at conserving the shape
        * addPoint tool
            - [ ] adds a point to the path upon click at position of mouse click
        * deletePoint tool
            - [ ] deletes a point from the path upon mouse click
        * addRegion tool
            - [ ] unifies two overlapping regions into one
        * deleteRegion tool
            - [ ] deletes a region upon click
        * splitRegion tool
            - [ ] splits one region at the intersection path with a second region
        * rotate tool
            - [ ] rotates a region around the point of mouse click
        * flip tool
            - [ ] flips a region around its vertical axis
        * toPolygon tool
            - [ ] converts the region path from bezier curve to polygon path
        * toBezier
            - [ ] converts the region path from polygon path to bezier curve
        * copy tool
            - [ ] copies a region
        * paste tool
            - [ ] pastes the copied region
        * save tool
            - [ ] saves the set of drawn regions to the database
        * screenshot tool
            - [ ] creates a screenshot of the data layer (not of the annotations yet) at a chosen resolution
        * delete tool
            - [ ] deletes the selected region
        * closeMenu tool
            - [ ] hides the menu bar upon click
        * openMenu tool
            - [ ] shows the menu bar upon click
        * undo tool
            - [ ] undoes the user's actions in reverse chronological order


<!-- Either: -->
- [ ] I implemented tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Again, many many thanks for your work! \ö/ -->

