### PR TITLE
added onDeselet for tool methods, moved drawpolygon ondeselect from m…

### DIFF
--- a/app/public/js/microdraw.js
+++ b/app/public/js/microdraw.js
@@ -1047,6 +1047,10 @@ var Microdraw = (function () {
                 }
             }
 
+            if(undo.callback && typeof undo.callback === 'function'){
+                undo.callback()
+            }
+
             /**
              * @todo This line produces an error when the undo object is undefined. However, the code seems to work fine without this line. Check what the line was supposed to do
              */

--- a/app/public/js/microdraw.js
+++ b/app/public/js/microdraw.js
@@ -1066,26 +1066,6 @@ var Microdraw = (function () {
         },
 
         /**
-         * @function finishDrawingPolygon
-         * @desc Tool selection
-         * @param {number} closed Binary value indicating whether to close the region or not
-         * @returns {void}
-         */
-        finishDrawingPolygon: function finishDrawingPolygon(closed) {
-                // finished the drawing of the polygon
-                if( closed === true ) {
-                    me.region.path.closed = true;
-                    me.region.path.fillColor.alpha = me.config.defaultFillAlpha;
-                } else {
-                    me.region.path.fillColor.alpha = 0;
-                }
-                me.region.path.fullySelected = true;
-                //region.path.smooth();
-                me.drawingPolygonFlag = false;
-                me.commitMouseUndo();
-        },
-
-        /**
          * @function backToPreviousTool
          * @param {string} prevTool Name of the previously selected tool
          * @returns {void}
@@ -1178,11 +1158,8 @@ var Microdraw = (function () {
                 console.log("> toolSelection");
             }
 
-            //end drawing of polygons and make open form
-            if( me.drawingPolygonFlag === true ) {
-                me.finishDrawingPolygon(true);
-            }
-
+            if( me.tools[prevTool] && me.tools[prevTool].onDeselect ) me.tools[prevTool].onDeselect()
+            
             var prevTool = me.selectedTool;
             me.selectedTool = $(this).attr("id");
             me.selectTool();

--- a/app/public/js/tools/drawPolygon.js
+++ b/app/public/js/tools/drawPolygon.js
@@ -33,9 +33,15 @@ var ToolDrawPolygon = {drawPolygon: (function() {
          */
          mouseDown: function mouseDown(point) {
             // is already drawing a polygon or not?
-            if( drawingPolygonFlag === false ) {
 
-                Microdraw.commitMouseUndo();    
+            /* mouseUndo.callback is expected to be a function */
+            Microdraw.mouseUndo.callback = ((currentFlag) => () => {
+                drawingPolygonFlag = currentFlag
+            })(drawingPolygonFlag)
+
+            Microdraw.commitMouseUndo();  
+
+            if( drawingPolygonFlag === false ) {
                 
                 // deselect previously selected region
                 if( Microdraw.region ) { Microdraw.region.path.selected = false; }

--- a/app/public/js/tools/drawPolygon.js
+++ b/app/public/js/tools/drawPolygon.js
@@ -39,8 +39,6 @@ var ToolDrawPolygon = {drawPolygon: (function() {
                 drawingPolygonFlag = currentFlag
             })(drawingPolygonFlag)
 
-            Microdraw.commitMouseUndo();  
-
             if( drawingPolygonFlag === false ) {
                 
                 // deselect previously selected region
@@ -66,6 +64,8 @@ var ToolDrawPolygon = {drawPolygon: (function() {
                     Microdraw.region.path.add(point);
                 }
             }
+
+            Microdraw.commitMouseUndo();  
         },
 
         /**
@@ -107,15 +107,6 @@ var ToolDrawPolygon = {drawPolygon: (function() {
                 }
             }
             paper.view.draw();
-        },
-
-        /**
-         * @function onDeselect
-         * @returns {void}
-         * @description called when user clicks another tool
-         */
-        onDeselect : function onDeselect(){
-            finishDrawingPolygon(true)
         },
 
         /*

--- a/app/public/js/tools/drawPolygon.js
+++ b/app/public/js/tools/drawPolygon.js
@@ -4,7 +4,7 @@
 var ToolDrawPolygon = {drawPolygon: (function() {
     
     /* can be changed/loaded via config  */
-    let drawingPolygonFlag = true
+    let drawingPolygonFlag = false
 
     /**
      * @function finishDrawingPolygon
@@ -21,7 +21,6 @@ var ToolDrawPolygon = {drawPolygon: (function() {
         }
         Microdraw.region.path.fullySelected = true;
         drawingPolygonFlag = false
-        Microdraw.commitMouseUndo();
     }
 
     var tool = {
@@ -35,6 +34,9 @@ var ToolDrawPolygon = {drawPolygon: (function() {
          mouseDown: function mouseDown(point) {
             // is already drawing a polygon or not?
             if( drawingPolygonFlag === false ) {
+
+                Microdraw.commitMouseUndo();    
+                
                 // deselect previously selected region
                 if( Microdraw.region ) { Microdraw.region.path.selected = false; }
 


### PR DESCRIPTION
…icrodraw.js to tools/drawPolygon.js

<!-- Thank you so much for your contribution to MicroDraw! <3 -->

In our use cases, there are often needs to have a callback when the tool is deselected. This PR implements a `onDeslect` method of the tools, that will be called when user selects a new tool. 

I have also partially patched `drawPolygon.js`, which can somewhat take advantage of the newly implemented method. 

The undo of individual points on the polygon has been temporarily disabled in this PR, as we have encountered some strange behaviours, which can be reproduced:
- use polygon tool draw a > 4 sided object
- select a different tool
- ctrl z

In this PR, ctrlZ will reset entire polygons. 

I would welcome any discussion on the behaviour of the polygon and make any changes. 

<!-- Please find a short title for your pull request and describe your changes on the following line: -->


---
<!-- Please go through our check list and replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `screenshot_test_walk` generates the same test pictures as there were and does not show any errors
- [ ] These changes fix #__ (github issue number if applicable).
- [x] All MicroDraw tools behave as expected:
    * **GESTURES**
        - [ ] zoom in and out with two finger drag works
    * **KEYS**
        * right and up arrow key or left and down arrow key
            - [ ] jump to next or previous slice respectively
            - [ ] update the slider accordingly
            - [ ] update the slice number accordingly
        * cmd z undoes
            - [ ] any step back that you have done in their chronological order including
            - [ ] translation of region
            - [ ] drawing region
            - [ ] adding point
            - [ ] deleting point
        to be completed (maybe it is implemented and working for all functions, so we can delete the single step checks)
    * **TOOL BUTTONS**
        * red rectangle in navigation window
            - [ ] corresponds to tissue piece selected in viewer
            - [ ] can be navigated upon mouse down drag
        * navigation tool
            - [ ] navigates the slice inside the viewer upon mouse down drag
        * home button
            - [ ] zooms out to view the data in full screen size view
        * zoomIn tool
            - [ ] zooms one step in upon click
        * zoomOut tool
            - [ ] zooms one step out upon click
        * left arrow
            - [ ] jumps to the previous slice
        * right arrow
            - [ ] jumps to the next slice
        * select tool
            - [ ] selects a region upon click
        * draw tool
            - [ ] draws a new region as bezier curve
        * drawPolygon tool
            - [x] draws a new region as a polygon path
        * simplify tool
            - [ ] decreases the number of points in the region path while aiming at conserving the shape
        * addPoint tool
            - [ ] adds a point to the path upon click at position of mouse click
        * deletePoint tool
            - [ ] deletes a point from the path upon mouse click
        * addRegion tool
            - [ ] unifies two overlapping regions into one
        * deleteRegion tool
            - [ ] deletes a region upon click
        * splitRegion tool
            - [ ] splits one region at the intersection path with a second region
        * rotate tool
            - [ ] rotates a region around the point of mouse click
        * flip tool
            - [ ] flips a region around its vertical axis
        * toPolygon tool
            - [ ] converts the region path from bezier curve to polygon path
        * toBezier
            - [ ] converts the region path from polygon path to bezier curve
        * copy tool
            - [ ] copies a region
        * paste tool
            - [ ] pastes the copied region
        * save tool
            - [ ] saves the set of drawn regions to the database
        * screenshot tool
            - [ ] creates a screenshot of the data layer (not of the annotations yet) at a chosen resolution
        * delete tool
            - [ ] deletes the selected region
        * closeMenu tool
            - [ ] hides the menu bar upon click
        * openMenu tool
            - [ ] shows the menu bar upon click
        * undo tool
            - [ ] undoes the user's actions in reverse chronological order


<!-- Either: -->
- [ ] I implemented tests for these changes OR
- [x] These changes do not require tests because test already exists

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Again, many many thanks for your work! \ö/ -->

