### PR TITLE
Fix save annotation

### DIFF
--- a/app/db/db.js
+++ b/app/db/db.js
@@ -104,14 +104,14 @@ module.exports = function(overwriteMongoPath){
 
     /**
      * 
-     * @param {Object} saveQuery having fields : fileID : string, user : string, annotationHash : string, annotation : JSON.stringify(Object { Regions : string[] }), hash : string
+     * @param {Object} saveQuery having fields : fileID : string, user : string, Hash : string, annotation : JSON.stringify(Object { Regions : string[] }), hash : string
      * @returns {Promise} to resolve when saving is complete
      */
     const updateAnnotation = (saveQuery)=> new Promise((resolve,reject)=>{
         if (!checkHealth()) {
             return reject('db connection not healthy')
         }
-        const { fileID , user, annotationHash, annotation } = saveQuery
+        const { fileID , user, Hash, annotation } = saveQuery
         db.get('annotations').update(
             Object.assign(
                 {},
@@ -124,7 +124,7 @@ module.exports = function(overwriteMongoPath){
             const arrayTobeSaved = allAnnotation.Regions.map(region=>({
                 fileID, 
                 user,
-                annotationHash ,
+                Hash ,
                 annotation : region
             }))
             db.get('annotations').insert(arrayTobeSaved)

--- a/app/db/db.js
+++ b/app/db/db.js
@@ -16,14 +16,25 @@ module.exports = function(overwriteMongoPath){
         console.log('connection error', e)
     })
 
+    /**
+     * @returns {boolean} checks mongodb connection
+     */
+    const checkHealth = () => connected
+
     /* add user */
     const addUser = (user)=>new Promise((resolve,reject)=>{
+        if (!checkHealth()) {
+            return reject('db connection not healthy')
+        }
         db.get('users').insert(user)
             .then(()=>resolve(user))
             .catch(e=>reject(e))
     })
 
     const updateUser = (user)=>new Promise((resolve,reject)=>{
+        if (!checkHealth()) {
+            return reject('db connection not healthy')
+        }
         db.get('user').update({
             username : user.username
         },{
@@ -34,12 +45,18 @@ module.exports = function(overwriteMongoPath){
 
     /* find user */
     const queryUser = (searchQuery)=>new Promise((resolve,reject)=>{
+        if (!checkHealth()) {
+            return reject('db connection not healthy')
+        }
         db.get('users').findOne(searchQuery)
             .then((user)=>user ? resolve(user) : reject({message:'error find one user',result:user}))
             .catch(e=>reject(e))
     })
 
     const upsertUser = (user)=> new Promise((resolve,reject)=>{
+        if (!checkHealth()) {
+            return reject('db connection not healthy')
+        }
         queryUser({
             username : user.username
         })
@@ -56,6 +73,9 @@ module.exports = function(overwriteMongoPath){
     })
 
     const queryAllUsers = (pagination)=>new Promise((resolve,reject)=>{
+        if (!checkHealth()) {
+            return reject('db connection not healthy')
+        }
         db.get('users').find(pagination)
             .then((users)=>users ? resolve(users) : reject({message : 'error find all users',result:users}))
             .catch(e=>reject(e))
@@ -67,6 +87,9 @@ module.exports = function(overwriteMongoPath){
      * @returns {Promise} to resolve as an array of annotations
      */
     const findAnnotations = (searchQuery)=>new Promise((resolve,reject)=>{
+        if (!checkHealth()) {
+            return reject('db connection not healthy')
+        }
         db.get('annotations').find(
             Object.assign({},searchQuery,{
                 backup : { $exists : false }
@@ -85,6 +108,9 @@ module.exports = function(overwriteMongoPath){
      * @returns {Promise} to resolve when saving is complete
      */
     const updateAnnotation = (saveQuery)=> new Promise((resolve,reject)=>{
+        if (!checkHealth()) {
+            return reject('db connection not healthy')
+        }
         const { fileID , user, annotationHash, annotation } = saveQuery
         db.get('annotations').update(
             Object.assign(
@@ -106,11 +132,6 @@ module.exports = function(overwriteMongoPath){
                 .catch(e=>reject(e))
         })
     })
-
-    /**
-     * @returns {boolean} checks mongodb connection
-     */
-    const checkHealth = () => connected
 
     return {
         addUser,

--- a/app/db/db.spec.js
+++ b/app/db/db.spec.js
@@ -38,19 +38,19 @@ describe('testing db.js',()=>{
             annotationkey2 : 'dummy annotation 1 annotation value 2',
             Regions : ['dummy annotation 1 region1','dummy annotation 1 region2']
         }),
-        annotationHash : 'abc123'
+        Hash : 'abc123'
     }
 
     const expectedSavedDummy = [{
         fileID : 'dummy fileID 1',
         user : 'tommy jones',
         annotation : 'dummy annotation 1 region2',
-        annotationHash : 'abc123'
+        Hash : 'abc123'
     },{
         fileID : 'dummy fileID 1',
         user : 'tommy jones',
         annotation : 'dummy annotation 1 region1',
-        annotationHash : 'abc123'
+        Hash : 'abc123'
     }]
 
     const dummyAnnotation_updated = {
@@ -61,19 +61,19 @@ describe('testing db.js',()=>{
             annotationkey2 : 'dummy annotation 1 annotation value 2 updated',
             Regions : ['dummy annotation 1 updated region1','dummy annotation 1 updated region2']
         }),
-        annotationHash : 'abc123 updated'
+        Hash : 'abc123 updated'
     }
 
     const expectedSavedDummyUpdated = [{
         fileID : 'dummy fileID 1',
         user : 'tommy jones',
         annotation : 'dummy annotation 1 updated region2',
-        annotationHash : 'abc123 updated'
+        Hash : 'abc123 updated'
     },{
         fileID : 'dummy fileID 1',
         user : 'tommy jones',
         annotation : 'dummy annotation 1 updated region1',
-        annotationHash : 'abc123 updated'
+        Hash : 'abc123 updated'
     }]
 
 
@@ -85,19 +85,19 @@ describe('testing db.js',()=>{
             annotationkey2 : 'dummy annotation 2 annotation value 2',
             Regions : ['dummy annotation 2 region1','dummy annotation 2 region2']
         }),
-        annotationHash : '123abc'
+        Hash : '123abc'
     }
 
     const expectedSavedDummy2 = [{
         fileID : 'dummy fileID 2',
         user : 'anonymouse',
         annotation : 'dummy annotation 2 region1',
-        annotationHash : '123abc'
+        Hash : '123abc'
     },{
         fileID : 'dummy fileID 2',
         user : 'anonymouse',
         annotation : 'dummy annotation 2 region2',
-        annotationHash : '123abc'
+        Hash : '123abc'
     }]
 
     before(()=>{
@@ -276,8 +276,8 @@ describe('testing db.js',()=>{
             })
                 .then(annotations=>{
                     annotations.forEach(anno=>{
-                        const { user, fileID, annotationHash, annotation } = anno
-                        expect(expectedSavedDummy).to.deep.include.members([{ user, fileID, annotationHash, annotation }])
+                        const { user, fileID, Hash, annotation } = anno
+                        expect(expectedSavedDummy).to.deep.include.members([{ user, fileID, Hash, annotation }])
                     })
                     done()
                 })
@@ -298,8 +298,8 @@ describe('testing db.js',()=>{
             })
                 .then(annotations=>{
                     annotations.forEach(anno=>{
-                        const { user, fileID, annotationHash, annotation } = anno
-                        expect(expectedSavedDummy2).to.deep.include.members([{ user, fileID, annotationHash, annotation }])
+                        const { user, fileID, Hash, annotation } = anno
+                        expect(expectedSavedDummy2).to.deep.include.members([{ user, fileID, Hash, annotation }])
                     })
                     done()
                 })
@@ -323,8 +323,8 @@ describe('testing db.js',()=>{
             })
                 .then(annotations=>{
                     annotations.forEach(anno=>{
-                        const { user, fileID, annotationHash, annotation } = anno
-                        expect(expectedSavedDummyUpdated).to.deep.include.members([{ user, fileID, annotationHash, annotation }])
+                        const { user, fileID, Hash, annotation } = anno
+                        expect(expectedSavedDummyUpdated).to.deep.include.members([{ user, fileID, Hash, annotation }])
                     })
                     done()
                 })

--- a/app/db/db.spec.js
+++ b/app/db/db.spec.js
@@ -116,6 +116,35 @@ describe('testing db.js',()=>{
         expect(garbageDb.checkHealth()).to.be.equal(false)
     })
 
+
+    describe('db operation with bad db health should result in error', () => {
+
+        const getTestGarbageDb = ({ prop, arg }) => (done) => (garbageDb[prop](arg)
+            .then(() => done('should not succeed'))
+            .catch(e => done()), null)
+        /**
+         * somewhat necessary to return NOT a promise. or else mocha will complain
+         */
+
+
+        /**
+         * user management
+         */
+        it('addUser throws', getTestGarbageDb({prop: 'addUser', arg: dummyUser}))
+        it('queryUser throws', getTestGarbageDb({prop: 'queryUser', arg: dummyUser}))
+        it('queryAllUsers throws', getTestGarbageDb({prop: 'queryAllUsers', arg: dummyUser}))
+        it('updateUser throws', getTestGarbageDb({prop: 'updateUser', arg: dummyUser}))
+        it('upsertUser throws', getTestGarbageDb({prop: 'upsertUser', arg: dummyUser}))
+
+        /**
+         * annotaiton managedment
+         */
+
+        it('findAnnotations throws', getTestGarbageDb({prop: 'findAnnotations', arg: dummyAnnotation}))
+        it('updateAnnotation throws', getTestGarbageDb({prop: 'updateAnnotation', arg: dummyAnnotation}))
+        
+    })
+
     it('querying the empty mongodb should not yield any results',(done)=>{
         db.queryUser({
             username : dummyUser.username

--- a/app/public/js/configuration.json
+++ b/app/public/js/configuration.json
@@ -4,7 +4,7 @@
     "regionOntology":true,
     "drawingEnabled":true,
     "removeTools":[],
-    "multiImageSave":false,
+    "multiImageSave":true,
     "presets":{
         "default":[
             {

--- a/app/public/js/microdraw.js
+++ b/app/public/js/microdraw.js
@@ -1389,6 +1389,7 @@ var Microdraw = (function () {
 
             // change current section index (for loading and saving)
             me.section = me.currentImage;
+            me.fileID = `${me.source}`
 
             // hide previous section
             if( me.prevImage && paper.projects[me.ImageInfo[me.prevImage].projectID] ) {

--- a/app/public/js/tools/save.js
+++ b/app/public/js/tools/save.js
@@ -45,9 +45,7 @@ var ToolSave = { save : (function(){
 
                 return;
             }
-            debugger
             value.Hash = h;
-            debugger
             savedSections += sl.toString() + " ";
 
             // post data to database

--- a/app/public/js/tools/save.js
+++ b/app/public/js/tools/save.js
@@ -40,12 +40,14 @@ var ToolSave = { save : (function(){
             if( Microdraw.debug > 1 ) { console.log("hash:", h, "original hash:", section.Hash); }
             // if the section hash is undefined, this section has not yet been loaded. do not save anything for this section
             if( typeof section.Hash === "undefined" || h === section.Hash ) {
-                if( Microdraw.debug > 1 ) { console.log("No change, no save"); }
+                if( Microdraw.debug > 1 ) { console.log(`sl ${sl}`, "No change, no save"); }
                 value.Hash = h;
 
                 return;
             }
+            debugger
             value.Hash = h;
+            debugger
             savedSections += sl.toString() + " ";
 
             // post data to database
@@ -56,8 +58,8 @@ var ToolSave = { save : (function(){
                         type:"POST",
                         data: {
                             action: "save",
-                            fileID: Microdraw.fileID,
-                            annotationHash: h2,
+                            fileID: `${Microdraw.source}&slice=${sl}`,
+                            Hash: h2,
                             annotation: JSON.stringify(value)
                         },
                         success: function(result) {
@@ -125,7 +127,7 @@ Microdraw.microdrawDBLoad = function(){
 
         $.getJSON(dbroot,{
             action : "load_last",
-            fileID : Microdraw.fileID
+            fileID : `${Microdraw.source}&slice=${Microdraw.currentImage}`
         })
             .success(function (data){
                 var i, json, reg;

--- a/app/routes/routes.js
+++ b/app/routes/routes.js
@@ -58,9 +58,9 @@ module.exports = (app)=>{
         app.db.updateAnnotation({
             fileID : req.body.fileID,
             user : req.user ? req.user.username : 'anonymouse',
-            annotationHash : req.body.annotationHash,
+            Hash : req.body.Hash,
             annotation :req.body.annotation})
-              .then(()=>res.status(200))
+              .then(()=>res.status(200).send())
               .catch(e=>res.status(500).send({err:JSON.stringify(e)}))
       }else{
           res.status(500).send({err:'actions other than save are no longer supported.'})


### PR DESCRIPTION
<!-- Thank you so much for your contribution to MicroDraw! <3 -->
Fix save annotation bug. Now saves to DB in the form of: `source + '&slice=' + slice_number`
<!-- Please find a short title for your pull request and describe your changes on the following line: -->


---
<!-- Please go through our check list and replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `screenshot_test_walk` generates the same test pictures as there were and does not show any errors
- [ ] These changes fix #__ (github issue number if applicable).
- [ ] All MicroDraw tools behave as expected:
    * **GESTURES**
        - [ ] zoom in and out with two finger drag works
    * **KEYS**
        * right and up arrow key or left and down arrow key
            - [ ] jump to next or previous slice respectively
            - [ ] update the slider accordingly
            - [ ] update the slice number accordingly
        * cmd z undoes
            - [ ] any step back that you have done in their chronological order including
            - [ ] translation of region
            - [ ] drawing region
            - [ ] adding point
            - [ ] deleting point
        to be completed (maybe it is implemented and working for all functions, so we can delete the single step checks)
    * **TOOL BUTTONS**
        * red rectangle in navigation window
            - [ ] corresponds to tissue piece selected in viewer
            - [ ] can be navigated upon mouse down drag
        * navigation tool
            - [ ] navigates the slice inside the viewer upon mouse down drag
        * home button
            - [ ] zooms out to view the data in full screen size view
        * zoomIn tool
            - [ ] zooms one step in upon click
        * zoomOut tool
            - [ ] zooms one step out upon click
        * left arrow
            - [ ] jumps to the previous slice
        * right arrow
            - [ ] jumps to the next slice
        * select tool
            - [ ] selects a region upon click
        * draw tool
            - [ ] draws a new region as bezier curve
        * drawPolygon tool
            - [x] draws a new region as a polygon path
        * simplify tool
            - [ ] decreases the number of points in the region path while aiming at conserving the shape
        * addPoint tool
            - [ ] adds a point to the path upon click at position of mouse click
        * deletePoint tool
            - [ ] deletes a point from the path upon mouse click
        * addRegion tool
            - [ ] unifies two overlapping regions into one
        * deleteRegion tool
            - [ ] deletes a region upon click
        * splitRegion tool
            - [ ] splits one region at the intersection path with a second region
        * rotate tool
            - [ ] rotates a region around the point of mouse click
        * flip tool
            - [ ] flips a region around its vertical axis
        * toPolygon tool
            - [ ] converts the region path from bezier curve to polygon path
        * toBezier
            - [ ] converts the region path from polygon path to bezier curve
        * copy tool
            - [ ] copies a region
        * paste tool
            - [ ] pastes the copied region
        * save tool
            - [ ] saves the set of drawn regions to the database
        * screenshot tool
            - [ ] creates a screenshot of the data layer (not of the annotations yet) at a chosen resolution
        * delete tool
            - [ ] deletes the selected region
        * closeMenu tool
            - [ ] hides the menu bar upon click
        * openMenu tool
            - [ ] shows the menu bar upon click
        * undo tool
            - [ ] undoes the user's actions in reverse chronological order


<!-- Either: -->
- [ ] I implemented tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Again, many many thanks for your work! \ö/ -->

