### PR TITLE
feat: added tests for token.js

### DIFF
--- a/app/auth/auth.js
+++ b/app/auth/auth.js
@@ -15,7 +15,7 @@ const _URL = (MONGODB.slice(0,10) === 'mongodb://'
 
 /* middle to ensure authenticated */
 const ensureAuthenticated = (req,res,next)=>{
-    if(req.isAuthenticated()){
+    if(req.user){
         return next()
     }
 
@@ -72,7 +72,7 @@ module.exports = (app)=>{
 
     /* TODO use reflection */
     app.get('/loggedIn', (req, res) => {
-        if (req.isAuthenticated()) {
+        if (req.user) {
             res.send({loggedIn: true, username: req.user.username});
         } else {
             res.send({loggedIn: false});

--- a/app/auth/github.js
+++ b/app/auth/github.js
@@ -6,7 +6,6 @@ const path = require('path')
 module.exports = (app)=>{
     try{
         const githubKeys = fs.readFileSync( path.join(__dirname,'github-keys.json'), 'utf-8' )
-
         const githubKeysJson = JSON.parse(githubKeys)
         passport.use(new GithubStrategy( githubKeysJson ,
             (accessToken, refreshToken, profile, done) => done(null, profile)))

--- a/app/auth/local.spec.js
+++ b/app/auth/local.spec.js
@@ -42,7 +42,7 @@ describe('testing local.js',()=>{
 
     require('./local')(app)
     app.get('/',(req,res)=>res.status(200))
-    app.listen(port,()=>console.log('app listening at port 3002'))
+    app.listen(port,()=>console.log(`app listening at port ${port}`))
   })
 
   it(`app listening at port ${port} correctly`,(done)=>{

--- a/app/auth/token.spec.js
+++ b/app/auth/token.spec.js
@@ -1,0 +1,238 @@
+const assert = require('assert')
+const express = require('express')
+const request = require('request')
+const chai = require('chai')
+const sinon = require('sinon')
+const expect = chai.expect
+const should = chai.should()
+
+describe('mocha works', () => {
+    it('mocha works property', () => {
+        assert(true)
+    })
+})
+
+describe('sinon works properly', () => {
+    const stub = sinon.stub()
+    it('works properly', () => {
+        expect(stub.called).to.be.false
+        stub()
+        expect(stub.called).to.be.true
+    })
+
+    const promiseStub = sinon.stub()
+    it('promises works properly', (done) => {
+        expect(promiseStub.called).to.be.false
+        promiseStub.resolves('apple')
+        promiseStub()
+            .then(result => {
+                expect(result).to.be.equal('apple')
+                done()
+            })
+            .catch(e => {
+                done('should not fail')
+            })
+    })
+})
+
+let _server
+
+const port = process.env.MOCHATEST_PORT || 10002
+const hostname = `http://localhost`
+
+const user = {
+    username: 'bob101'
+}
+
+describe('if db is not define, reponses are as expected', () => {
+    before(() => {
+        const app = express()
+        require('./token')(app)
+        _server = app.listen(port, () => console.log(`application listening on port ${port}`))
+    })
+    after(() => {
+        if(_server)
+            _server.close()
+    })
+    it('if db not initialised, GET /token should turn 500', (done) => {
+
+        request(`${hostname}:${port}/token`, (err, res, body) => {
+            expect(err).to.be.null
+            expect(res).to.be.not.null
+            expect(res.statusCode).to.be.equal(500)
+            done()
+        })
+    })
+})
+
+const generateToken = ({ token='token name', expiryDate=new Date(), username='bob' }) => {
+    return {
+        token,
+        expiryDate,
+        username
+    }
+}
+
+const spy = sinon.spy((req, res) => {
+    const {isTokenAuthenticated, tokenUsername} = req
+    res.status(200).json({isTokenAuthenticated, tokenUsername})
+})
+
+describe('get token when not logged in works as intended', () => {
+
+    let addTokenFake = sinon.fake.resolves(generateToken({
+        username: 'bob',
+        token: 'bla bla'
+    }))
+    beforeEach(() => {
+        spy.resetHistory()
+    })
+    before(() => {
+        const app = express()
+        app.db = {
+            addToken: addTokenFake
+        }
+        require('./token')(app)
+        app.get('/spy', spy)
+        app.get('/dummy', (req, res) => {
+            const { isTokenAuthenticated, tokenUsername } = req
+            res.status(200).json({ isTokenAuthenticated, tokenUsername })
+        })
+        _server = app.listen(port, () => console.log(`application listening on port ${port}`))
+    })
+    
+    after(() => {
+        if (_server)
+            _server.close()
+    })
+
+    afterEach(() => {
+        spy.resetHistory()
+    })
+
+    it('if not logged in, GET /token should return 401', (done) => {
+        request(`${hostname}:${port}/token`, (err, res, body) => {
+            expect(err).to.be.null
+            expect(res).to.be.not.null
+            expect(res.statusCode).to.be.equal(401)
+            expect(addTokenFake.called).to.equal(false)
+            done()
+        })
+    })
+
+    it('if not logged in, middlewhare should not populate token properties', (done) => {
+        request(`${hostname}:${port}/spy`, (err, res, body) => {
+
+            assert(spy.called)
+            const arg = spy.getCall(0)
+            const {isTokenAuthenticated ,tokenUsername} = arg.args[0]
+            expect(!!isTokenAuthenticated).to.be.equal(false)
+            expect(!!tokenUsername).to.be.equal(false)
+            done()
+        })
+    })
+})
+
+describe('get toekn when logged in works as intended', () => {
+
+    let setUserFlag = true
+
+    let addTokenStub = sinon.stub()
+    addTokenStub.resolvesArg(0)
+
+    let findTokenStub = sinon.stub()
+    const expiredToken = generateToken({
+        username: 'bob101',
+        token: '101',
+        expiryDate: new Date(new Date().getTime() - 1e6)
+    })
+    const unexpiredToken = generateToken({
+        username: 'bob102',
+        token: '102',
+        expiryDate: new Date(new Date().getTime() + 1e6)
+    })
+    findTokenStub.onCall(0).resolves(unexpiredToken)
+    findTokenStub.onCall(1).resolves(expiredToken)
+
+    beforeEach(() => {
+        findTokenStub.resetHistory()
+        spy.resetHistory()
+        setUserFlag = false
+    })
+    
+    before(() => {
+        const app = express()
+        app.db = {
+            addToken: addTokenStub,
+            findToken: findTokenStub
+        }
+        app.use((req, res, next) => {
+            if (setUserFlag) {
+                req.user = user
+            }
+            next()
+        })
+        require('./token')(app)
+        app.get('/spy', spy)
+        app.get('/dummy', (req, res) => {
+            const { isTokenAuthenticated, tokenUsername } = req
+            res.status(200).json({ isTokenAuthenticated, tokenUsername })
+        })
+        _server = app.listen(port, () => console.log(`application listening on port ${port}`))
+    })
+    
+    after(() => {
+        if (_server)
+            _server.close()
+    })
+
+    it('if user is logged in, GET /token should return token', (done) => {
+        setUserFlag = true
+        request(`${hostname}:${port}/token`, (err, res, body) => {
+            expect(err).to.be.null
+            expect(res).to.be.not.null
+            expect(res.statusCode).to.be.equal(200)
+            expect(addTokenStub.called).to.equal(true)
+            done()
+        })
+    })
+
+    it('unexpired token should grant user access', (done) => {
+        
+        expect(spy.called).to.be.equal(false)
+        expect(findTokenStub.called).to.be.equal(false)
+        request(`${hostname}:${port}/spy?token=${unexpiredToken.token}`, (err, res, body) => {
+            expect(err).to.be.null
+            expect(findTokenStub.called).to.be.true
+            expect(res.statusCode).to.be.equal(200)
+            assert(spy.called)
+            const arg = spy.getCall(0)
+            const {isTokenAuthenticated ,tokenUsername, user} = arg.args[0]
+            expect(isTokenAuthenticated).to.be.equal(true)
+            expect(tokenUsername).to.be.equal('bob102')
+            expect(user).to.be.deep.equal({ username: 'bob102' })
+            done()
+        })
+    })
+
+    it('expired token should reject user access with message', (done) => {
+        expect(spy.called).to.be.equal(false)
+        expect(findTokenStub.called).to.be.equal(false)
+        /**
+         * burn the first fn call, second one will return the expired token
+         */
+        findTokenStub()
+        request(`${hostname}:${port}/spy?token=${expiredToken.token}`, (err, res, body) => {
+            expect(err).to.be.null
+            expect(findTokenStub.called).to.be.true
+            expect(res.statusCode).to.be.equal(200)
+            assert(spy.called)
+            const arg = spy.getCall(0)
+            const {isTokenAuthenticated ,tokenUsername, user} = arg.args[0]
+            expect(isTokenAuthenticated).to.be.equal(false)
+            expect(tokenUsername).to.be.equal('bob101')
+            expect(!!user).to.be.false
+            done()
+        })
+    })
+})

--- a/app/controller/api/api.spec.js
+++ b/app/controller/api/api.spec.js
@@ -74,7 +74,7 @@ describe('testing api', () => {
                 expect(res).to.have.status(200)
                 assert(findAnnotations.calledWith({
                     fileID: '/path/to/json.json&slice=42',
-                    user: 'anonymouse'
+                    user: 'anonymous'
                 }))
                 done()
             })
@@ -98,7 +98,7 @@ describe('testing api', () => {
                 const { action, source, slice, ...rest } = sendItem
                 assert(updateAnnotation.calledWith({
                     fileID: '/path/to/json.json&slice=24',
-                    user: 'anonymouse',
+                    user: 'anonymous',
                     ...rest
                 }))
 

--- a/app/controller/api/index.js
+++ b/app/controller/api/index.js
@@ -6,13 +6,7 @@ router.get('', function (req, res) {
 
     console.warn("call to GET api");
 
-    let user = 'anonymous';
-    if (req.user) {
-        user = req.user.username;
-    } else
-    if (req.isTokenAuthenticated) {
-        user = req.tokenUsername;
-    }
+    const user = (req.user && req.user.username) || 'anonymous';
 
     console.warn(req.query);
     const { source, slice } = req.query;
@@ -32,13 +26,7 @@ router.post('', function (req, res) {
     if(req.body.action === 'save') {
         const { source, slice, Hash, annotation } = req.body;
 
-        let user = 'anonymous';
-        if (req.user) {
-            user = req.user.username;
-        } else
-        if (req.isTokenAuthenticated) {
-            user = req.tokenUsername;
-        }
+        const user = (req.user && req.user.username) || 'anonymous';
 
         req.app.db.updateAnnotation({
             fileID : `${source}&slice=${slice}`,

--- a/app/controller/api/index.js
+++ b/app/controller/api/index.js
@@ -2,12 +2,12 @@ const express = require('express');
 const router = express.Router();
 
 // API routes
-router.get('', tokenAuthentication, function (req, res) {
+router.get('', function (req, res) {
 
     console.warn("call to GET api");
 
     let user = 'anonymous';
-    if (req.isAuthenticated()) {
+    if (req.user) {
         user = req.user.username;
     } else
     if (req.isTokenAuthenticated) {
@@ -33,7 +33,7 @@ router.post('', function (req, res) {
         const { source, slice, Hash, annotation } = req.body;
 
         let user = 'anonymous';
-        if (req.isAuthenticated()) {
+        if (req.user) {
             user = req.user.username;
         } else
         if (req.isTokenAuthenticated) {

--- a/app/controller/user/user.controller.js
+++ b/app/controller/user/user.controller.js
@@ -20,7 +20,7 @@ const validator = function (req, res, next) {
 };
 
 const user = function (req, res) {
-    const login = (req.isAuthenticated()) ?
+    const login = (req.user) ?
                 ('<a href=\'/user/' + req.user.username + '\'>' + req.user.username + '</a> (<a href=\'/logout\'>Log Out</a>)') :
                 ('<a href=\'/auth/github\'>Log in with GitHub</a>');
     const requestedUser = req.params.userName;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "node ./bin/www",
     "test": "node test.js",
-    "mocha": "node node_modules/mocha/bin/mocha"
+    "mocha": "node node_modules/mocha/bin/mocha",
+    "lint": "eslint"
   },
   "dependencies": {
     "bcrypt": "^3.0.5",

--- a/test/mocha.test.js
+++ b/test/mocha.test.js
@@ -4,4 +4,15 @@
 
 require('../app/routes/routeExtensions.spec')
 require('../app/controller/api/api.spec')
+
+/**
+ * testing auth
+ */
+require('../app/auth/token.spec')
+// require('../app/auth/local.spec')
+require('../app/auth/auth.spec')
+
+/**
+ * testing db
+ */
 require('../app/db/db.spec')


### PR DESCRIPTION
<!-- Thank you so much for your contribution to MicroDraw! <3 -->

Modified `token.js` and make mocha tests to work again.

Instead of using a global function, now the `token` middlewear parses all incoming requests, and adds user object if the token is not yet expired.

The PR modifies the original codes a little bit, but I feel it somewhat conforms with the spirit of passportjs (authenticated requests, `req.user` is populated with user info)

<!-- Please find a short title for your pull request and describe your changes on the following line: -->

<!-- Please run our tests -->
- [x] Run `npm test` successfully. 
- [x] Run `npm run mocha`successfully.

- [x] `test_screenshots` generates the same test pictures in `test` as there were in `test/reference` and does not show any errors

<!-- Either: -->
- [x] I implemented tests for the new changes OR
- [ ] These changes do not require tests because _____

- [ ] These changes fix #__ (github issue number if applicable).

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Again, many many thanks for your work! \ö/ -->

