### PR TITLE
feat: appending with upload

### DIFF
--- a/app/controller/api/api.spec.js
+++ b/app/controller/api/api.spec.js
@@ -4,11 +4,30 @@ const bodyParser = require('body-parser');
 const chaiHttp = require('chai-http')
 const expect = chai.expect
 const sinon = require('sinon')
+const fs = require('fs')
 
 const express = require('express')
 const app = express()
+
 app.use(bodyParser.urlencoded({ extended: false }))
+
+/**
+ * simulate authenication status
+ * testing authentication is not the aim of this test suite
+ * these tests only check if api works as intended
+ */
+let authenticated = false
+const USER = 'bobby'
+app.use((req, res, next) => {
+    if (authenticated) {
+        req.user = {
+            username: USER
+        }
+    }
+    next()
+})
 app.use(require('./index'))
+
 chai.use(chaiHttp)
 
 describe('Mocha works', () => {
@@ -37,14 +56,18 @@ describe('sinon works', () => {
     })
 })
 
-describe('testing api', () => {
+describe('controller/api/index.js', () => {
+    const annoationInDb = {
+        Regions: ['hello: world', 'foobar']
+    }
     let _server,
         port = 10002,
-        url = `http://127.0.0.1:${port}`
+        url = `http://127.0.0.1:${port}`,
+    
+        returnFoundAnnotation = true,
         updateAnnotation = sinon.fake.resolves(), 
-        findAnnotations = sinon.fake.resolves([{
-            hello:'world'
-        }])
+        findAnnotations = sinon.fake.resolves(returnFoundAnnotation ? annoationInDb : {Regions: []})
+    
     before(() => {
         app.db = {
             updateAnnotation,
@@ -105,4 +128,136 @@ describe('testing api', () => {
                 done()
             })
     })
+    /**
+     * TODO: merge with other #saveFromAPI when #192 is merged
+     * appended to the end for now to avoid merge conflicts
+     */
+    describe('#saveFromAPI?action=append', () => {
+    
+        let FILENAME1 = `FILENAME1.json`
+        let FILENAME2 = `FILENAME2.json`
+        const correctJson = [
+            {
+                "annotation": {
+                    "path": [
+                        "Path",
+                        {
+                            "applyMatrix": true,
+                            "segments": [
+                                [345, 157],
+                                [386, 159],
+                                [385, 199]
+                            ],
+                            "closed": true,
+                            "fillColor": [0.1, 0.7, 0.6, 0.5],
+                            "strokeColor": [0, 0, 0],
+                            "strokeScaling": false
+                        }
+                    ],
+                    "name": "Contour 1"
+                }
+            },
+            {
+                "annotation": {
+                    "path": [
+                        "Path",
+                        {
+                            "applyMatrix": true,
+                            "segments": [
+                                [475, 227],
+                                [502, 155],
+                                [544, 221]
+                            ],
+                            "closed": true,
+                            "fillColor": [0.0, 0.0, 0.6, 0.5],
+                            "strokeColor": [0, 0, 0],
+                            "strokeScaling": false
+                        }
+                    ],
+                    "name": "Contour 2"
+                }
+            }
+        ]
+    
+        const incorrectJSON = {
+            hello: "world"
+        }
+
+        const getQueryParam = ({ action = 'append' } = {}) => ({
+            source: '/path/to/json.json',
+            slice: 24,
+            Hash: 'hello world',
+            action
+        })
+
+        const makeChaiRequest = ({ action = 'append' } = {}) => chai.request(url)
+            .post('/upload')
+            .attach('data', fs.readFileSync(FILENAME1), FILENAME1)
+            .query(getQueryParam())
+    
+        let readFileStub
+        
+        beforeEach(() => {
+            authenticated = true
+            returnFoundAnnotation = true
+
+            readFileStub = sinon.stub(fs, 'readFileSync')
+            readFileStub.returns(Buffer.from(JSON.stringify(correctJson)))
+
+            authenticated = true
+        })
+    
+        afterEach(() => {
+            readFileStub.restore()
+        })
+
+        it('response is as expected', (done) => {
+            const action = 'append'
+            makeChaiRequest({ action })
+                .end((err, res) => {
+                    assert(!err)
+                    expect(res.status).equal(200)
+                    done()
+                })
+        })
+
+        it('db.findAnnotation called', (done) => {
+            const action = 'append'
+            makeChaiRequest({ action })
+                .end((err, res) => {
+                    assert(!err)
+                    assert(findAnnotations.called)
+
+                    const { source, slice, Hash, action } = getQueryParam()
+                    assert(findAnnotations.calledWith({
+                        fileID: `${source}&slice=${slice}`,
+                        user: USER
+                    }))
+                    done()
+                })
+        })
+
+        it('db.updateAnnotation called', (done) => {
+            const action = 'append'
+            makeChaiRequest({ action })
+                .end((err, res) => {
+                    assert(!err)
+                    assert(updateAnnotation.called)
+                    const { source, slice, Hash, action } = getQueryParam()
+                    const { Regions } = annoationInDb
+                    const annotation = {
+                        Regions: Regions.concat(correctJson.map(v => v.annotation))
+                    }
+
+                    assert(updateAnnotation.calledWith({
+                        fileID: `${source}&slice=${slice}`,
+                        user: USER,
+                        Hash,
+                        annotation: JSON.stringify(annotation)
+                    }))
+                    done()
+                })
+        })
+    })
 })
+


### PR DESCRIPTION
 use query param  action=append

using `action=append` instead of `action=save` during programmatic upload allow the regions to be appended instead of overwritting existing regions

<!-- Thank you so much for your contribution to MicroDraw! <3 -->

<!-- Please find a short title for your pull request and describe your changes on the following line: -->

<!-- Please run our tests -->
- [x] Run `npm test` successfully. 
- [x] Run `npm run mocha`successfully.

- [x] `test_screenshots` generates the same test pictures in `test` as there were in `test/reference` and does not show any errors

<!-- Either: -->
- [x] I implemented tests for the new changes OR
- [ ] These changes do not require tests because _____

- [x] These changes fix #190  (github issue number if applicable).

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Again, many many thanks for your work! \ö/ -->

