### PR TITLE
bugfix: load new images deselect regions if any

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,11 @@ jobs:
             MONGODB_TEST : 127.0.0.1:27017/circleci_test
           background: true
       - run: sleep 5
+      # microdraw.spec.js needs a clean mongodb instance
+      # hence run before Query host
+      - run: 
+          name: Test microdraw.js
+          command: npm run mocha -- ./test/e2e/microdraw.spec.js
       - run:
           name: Query host
           command: 'node host.js'

--- a/app/public/js/microdraw.js
+++ b/app/public/js/microdraw.js
@@ -1321,6 +1321,11 @@ var Microdraw = (function () {
          */
         loadImage: function loadImage(imageNumber) {
             if( me.debug ) { console.log("> loadImage(" + imageNumber + ")"); }
+
+            // when load a new image, deselect any currently selecting regions
+            // n.b. this needs to be called before me.currentImage is set
+            me.selectRegion(null);
+
             // save previous image for some (later) cleanup
             me.prevImage = me.currentImage;
 

--- a/test/e2e/microdraw.spec.js
+++ b/test/e2e/microdraw.spec.js
@@ -1,0 +1,99 @@
+const { expect } = require('chai')
+const { DRAWPOLYGON, NEXT } = require('../UI')
+
+const pptr = require('puppeteer')
+let browser
+
+const delay = ms => new Promise(rs => {
+  setTimeout(rs, ms)
+})
+
+describe('microdraw.js', () => {
+  beforeEach(async () => {
+    browser = await pptr.launch({headless: false, args: ['--no-sandbox', '--disable-setuid-sandbox'] })
+  })
+  afterEach(async () => {
+    await browser && browser.close()
+  })
+  describe('behaviour of paperjs regions on image transition', () => {
+    let page
+    beforeEach(async () => {
+      page = await browser.newPage()
+      await page.goto('http://localhost:3000/data?source=/test_data/cat.json&slice=0', { waitUntil: 'networkidle2' })
+      await delay(100)
+    })
+
+    afterEach(async () => {
+      await page.close()
+    })
+    it('should deselect region on page transition', async () => {
+
+      // n.b. evaluate can only return serializable objects
+      const ImageInfo1 = await page.evaluate(`Microdraw['ImageInfo']`)
+      
+      expect(ImageInfo1['1'].Regions.length).to.be.equal(0)
+      expect(ImageInfo1['0'].Regions.length).to.be.equal(0)
+
+      await page.click(DRAWPOLYGON)
+
+      await page.mouse.click(400, 400)
+      await page.mouse.click(500, 400)
+      await page.mouse.click(500, 500)
+      await page.mouse.click(400, 500)
+      await page.mouse.click(400, 400)
+
+      const ImageInfo2 = await page.evaluate(() => {
+        // IIEF avoiding poisoning global scope
+        return (() => {
+
+          const returnObj = {}
+          for (const key in Microdraw.ImageInfo){
+            const { Regions, ...rest } = Microdraw.ImageInfo[key]
+            returnObj[key] = {
+              ...rest,
+              Regions: Regions.map(region => region.path.exportJSON())
+            }
+          }
+  
+          return Promise.resolve(returnObj)
+        })()
+      })
+
+      expect(ImageInfo2['1'].Regions.length).to.be.equal(0)
+      expect(ImageInfo2['0'].Regions.length).to.be.equal(1)
+      const regionJson = JSON.parse(ImageInfo2['0'].Regions[0])
+      expect(regionJson[1]['selected']).to.be.equal(true)
+
+      // go to next page
+
+      await page.click(NEXT)
+      await delay(500)
+
+      const newUrl = page.url()
+      expect(newUrl).to.contain('slice=1')
+
+      const ImageInfo3 = await page.evaluate(() => {
+        // IIEF avoiding poisoning global scope
+        return (() => {
+
+          const returnObj = {}
+          for (const key in Microdraw.ImageInfo){
+            const { Regions, ...rest } = Microdraw.ImageInfo[key]
+            returnObj[key] = {
+              ...rest,
+              Regions: Regions.map(region => region.path.exportJSON())
+            }
+          }
+  
+          return Promise.resolve(returnObj)
+        })()
+      })
+
+      expect(ImageInfo3['1'].Regions.length).to.be.equal(0)
+      expect(ImageInfo3['0'].Regions.length).to.be.equal(1)
+      const regionJsonAfter = JSON.parse(ImageInfo3['0'].Regions[0])
+      expect(!!regionJsonAfter[1]['selected']).to.be.equal(false)
+
+    })
+  })
+})


### PR DESCRIPTION
Finally getting around (partial) fixing #178 . 

This patch should result in any region deselected on image load

<!-- Thank you so much for your contribution to MicroDraw! <3 -->

<!-- Please find a short title for your pull request and describe your changes on the following line: -->

<!-- Please run our tests -->
- [x] Run `npm test` successfully. 
- [x] Run `npm run mocha`successfully.

- [x] `test_screenshots` generates the same test pictures in `test` as there were in `test/reference` and does not show any errors

<!-- Either: -->
- [x] I implemented tests for the new changes OR
- [ ] These changes do not require tests because _____

- [x] These changes partial fix #178  (github issue number if applicable).

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Again, many many thanks for your work! \ö/ -->

