### PR TITLE
bugfix: do not select region on db load

### DIFF
--- a/app/public/js/microdraw.js
+++ b/app/public/js/microdraw.js
@@ -1463,6 +1463,10 @@ var Microdraw = (function () {
                                 me.newRegion({name:reg.name, path:reg.path});
                             }
                             paper.view.draw();
+
+                            // on db load, do not select any region by default
+                            me.selectRegion(null);
+                            
                             // if image has no hash, save one
                             me.ImageInfo[me.currentImage].Hash = (data.Hash ? data.Hash : me.hash(JSON.stringify(me.ImageInfo[me.currentImage].Regions)).toString(16));
 


### PR DESCRIPTION
<!-- Thank you so much for your contribution to MicroDraw! <3 -->

This should fix the other half of #178 . On load, regions are not selected.

<!-- Please find a short title for your pull request and describe your changes on the following line: -->

<!-- Please run our tests -->
- [x] Run `npm test` successfully. 
- [x] Run `npm run mocha`successfully.

- [x] `test_screenshots` generates the same test pictures in `test` as there were in `test/reference` and does not show any errors

<!-- Either: -->
- [ ] I implemented tests for the new changes OR
- [x] These changes do not require tests because: will implement in future PR (specifically in `test/e2e/microdraw.js`)

- [x] These changes partial fix #178 (github issue number if applicable).

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Again, many many thanks for your work! \ö/ -->

